### PR TITLE
feat: 전 밴드 테마 적응형 카드 배경 추가

### DIFF
--- a/.github/scripts/waka_card.py
+++ b/.github/scripts/waka_card.py
@@ -43,6 +43,8 @@ class Theme:
     sub: str
     mute: str
     faint: str
+    card_bg: str
+    card_stroke: str
     panel: str
     panel_stroke: str
     track: str
@@ -54,13 +56,15 @@ class Theme:
 DARK = Theme(
     key="dark",
     foreground="#f0f6fc", foreground2="#c9d1d9", sub="#8b949e", mute="#7d8590", faint="#5b6470",
-    panel="#10161e", panel_stroke="#20262e", track="#161b22", divider="#1c222a",
+    card_bg="#0d1117", card_stroke="#20262e",
+    panel="#161b22", panel_stroke="#283039", track="#1c222b", divider="#222a33",
     blue=BLUE_D,
     heat=("#161b22", "#0d2d4a", "#15487f", "#2f6fc0", "#58A6FF"),
 )
 LIGHT = Theme(
     key="light",
     foreground="#1f2328", foreground2="#3a424b", sub="#57606a", mute="#6e7781", faint="#9aa3ad",
+    card_bg="#ffffff", card_stroke="#d0d7de",
     panel="#f4f6f8", panel_stroke="#d8dee4", track="#e7ebef", divider="#d8dee4",
     blue=BLUE,
     heat=("#ebedf0", "#bcd7f5", "#7fb1ec", "#4a8de0", "#1f6fdb"),
@@ -441,8 +445,14 @@ BANDS = [
 def render_band(draw, data: WakaData, theme: Theme) -> str:
     canvas = Canvas(theme)
     gradients(canvas)
-    height = draw(canvas, data)
-    return wrap(canvas, height + 14)
+    bg_index = len(canvas.parts)
+    content_height = draw(canvas, data)
+    total = content_height + 14
+    # 밴드별 카드 배경 (테마 적응) — 위/아래 6px 투명 여백으로 스택 시 카드 간 간극
+    background = (f'<rect x="1" y="6" width="{WIDTH - 2}" height="{total - 12:.0f}" rx="16" '
+                 f'fill="{theme.card_bg}" stroke="{theme.card_stroke}"/>')
+    canvas.parts.insert(bg_index, background)
+    return wrap(canvas, total)
 
 
 def readme_snippet() -> str:

--- a/cards/header-dark.svg
+++ b/cards/header-dark.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="84" rx="16" fill="#0d1117" stroke="#20262e"/>
 <rect x="18.0" y="20.0" width="48.0" height="48.0" rx="13" fill="url(#g_blue)"/>
 <text x="42.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="21" font-weight="700" fill="#fff" text-anchor="middle">R</text>
 <text x="80.0" y="40.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="23" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.2">devRavit</text>
@@ -13,7 +14,7 @@
 <rect x="718.1" y="28.0" width="103.9" height="26.0" rx="13" fill="#11243b" stroke="#58A6FF" stroke-width="1"/>
 <circle cx="731.1" cy="41" r="3.5" fill="#58A6FF"/>
 <text x="742.1" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">AI-Native</text>
-<rect x="605.2" y="28.0" width="103.9" height="26.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="605.2" y="28.0" width="103.9" height="26.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="616.2" y="45.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#f0f6fc" text-anchor="start">🦉</text>
 <text x="634.2" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">Night Owl</text>
 <rect x="485.2" y="28.0" width="111.0" height="26.0" rx="13" fill="#2a1a10" stroke="#D97757" stroke-width="1"/>

--- a/cards/header-light.svg
+++ b/cards/header-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="84" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <rect x="18.0" y="20.0" width="48.0" height="48.0" rx="13" fill="url(#g_blue)"/>
 <text x="42.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="21" font-weight="700" fill="#fff" text-anchor="middle">R</text>
 <text x="80.0" y="40.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="23" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.2">devRavit</text>

--- a/cards/heatmap-dark.svg
+++ b/cards/heatmap-dark.svg
@@ -6,8 +6,9 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="133" rx="16" fill="#0d1117" stroke="#20262e"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Last 30 days</text>
-<line x1="125" y1="10" x2="726" y2="10" stroke="#1c222a"/>
+<line x1="125" y1="10" x2="726" y2="10" stroke="#222a33"/>
 <text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">19일 연속 활동 🔥</text>
 <rect x="18.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
 <rect x="45.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#2f6fc0"/>
@@ -46,7 +47,7 @@
 <rect x="97.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#2f6fc0"/>
 <rect x="112.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#58A6FF"/>
 <text x="131.0" y="78.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">More</text>
-<line x1="18" y1="100.96666666666667" x2="822" y2="100.96666666666667" stroke="#1c222a"/>
+<line x1="18" y1="100.96666666666667" x2="822" y2="100.96666666666667" stroke="#222a33"/>
 <text x="18.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">저는 저녁형 인간이에요 🦉 · 피크 00:00–01:00 · 평균 10 hrs 7 mins/day</text>
 <text x="822.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">powered by WakaTime</text>
 </svg>

--- a/cards/heatmap-light.svg
+++ b/cards/heatmap-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="133" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Last 30 days</text>
 <line x1="125" y1="10" x2="726" y2="10" stroke="#d8dee4"/>
 <text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">19일 연속 활동 🔥</text>

--- a/cards/hero-dark.svg
+++ b/cards/hero-dark.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="258" rx="16" fill="#0d1117" stroke="#20262e"/>
 <rect x="18.0" y="14.0" width="804.0" height="150.0" rx="16" fill="#1a130f" stroke="#3a2a20" stroke-width="1"/>
 <circle cx="93" cy="89" r="52" fill="none" stroke="#241a14" stroke-width="13"/>
 <circle cx="93" cy="89" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 93 89)"/>
@@ -16,25 +17,25 @@
 <text x="194.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">AI</text>
 <text x="220.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">50.8K</text>
 <text x="794.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">100%</text>
-<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="url(#g_claude)"/>
 <circle cx="182" cy="98" r="4" fill="#2EA043"/>
 <text x="194.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">Human</text>
 <text x="242.0" y="102.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">1</text>
 <text x="794.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#7d8590" text-anchor="end">0%</text>
-<rect x="178.0" y="110.0" width="616.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="178.0" y="110.0" width="616.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="178.0" y="110.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
-<rect x="18.0" y="180.0" width="191.2" height="70.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="18.0" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="34.0" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">50.8K</text>
 <text x="34.0" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">AI line changes</text>
-<rect x="222.2" y="180.0" width="191.2" height="70.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="222.2" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="238.2" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">3.71B</text>
 <text x="315.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#58A6FF" text-anchor="start">B</text>
 <text x="238.2" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">tokens in · 5.6M out</text>
-<rect x="426.5" y="180.0" width="191.2" height="70.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="426.5" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="442.5" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">$10,774</text>
 <text x="442.5" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">est. cost · 7 days</text>
-<rect x="630.8" y="180.0" width="191.2" height="70.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="630.8" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="646.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">89</text>
 <text x="646.8" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">lines / prompt</text>
 </svg>

--- a/cards/hero-light.svg
+++ b/cards/hero-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="258" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <rect x="18.0" y="14.0" width="804.0" height="150.0" rx="16" fill="#fbf1ea" stroke="#f0d9cb" stroke-width="1"/>
 <circle cx="93" cy="89" r="52" fill="none" stroke="#f2ddd0" stroke-width="13"/>
 <circle cx="93" cy="89" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 93 89)"/>

--- a/cards/rhythm-dark.svg
+++ b/cards/rhythm-dark.svg
@@ -6,8 +6,9 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="218" rx="16" fill="#0d1117" stroke="#20262e"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">When I code</text>
-<line x1="117" y1="10" x2="311" y2="10" stroke="#1c222a"/>
+<line x1="117" y1="10" x2="311" y2="10" stroke="#222a33"/>
 <text x="407.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">00:00–01:00</text>
 <clipPath id="todclip"><rect x="18" y="36" width="389.0" height="13" rx="6"/></clipPath>
 <g clip-path="url(#todclip)">
@@ -33,7 +34,7 @@
 <text x="34.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌃 밤</text>
 <text x="407.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">8.2%</text>
 <text x="433.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Weekday</text>
-<line x1="499" y1="10" x2="726" y2="10" stroke="#1c222a"/>
+<line x1="499" y1="10" x2="726" y2="10" stroke="#222a33"/>
 <text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">peak 월요일</text>
 <rect x="433.0" y="36.0" width="48.7" height="110.0" rx="4" fill="url(#g_peak)"/>
 <text x="457.4" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="middle">월</text>
@@ -49,7 +50,7 @@
 <text x="740.9" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">토</text>
 <rect x="773.3" y="75.1" width="48.7" height="70.9" rx="4" fill="#5b6470"/>
 <text x="797.6" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">일</text>
-<rect x="18.0" y="182.0" width="804.0" height="34.0" rx="10" fill="#0e1722" stroke="#20262e" stroke-width="1"/>
+<rect x="18.0" y="182.0" width="804.0" height="34.0" rx="10" fill="#0e1722" stroke="#283039" stroke-width="1"/>
 <text x="34.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🏆 가장 생산적인 날</text>
 <text x="806.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="end">수요일 · 13 hrs 8 mins</text>
 <text x="420.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="middle">🔥 19일 연속 · 최장 몰입 3h 9m</text>

--- a/cards/rhythm-light.svg
+++ b/cards/rhythm-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="218" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">When I code</text>
 <line x1="117" y1="10" x2="311" y2="10" stroke="#d8dee4"/>
 <text x="407.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">00:00–01:00</text>

--- a/cards/stack-dark.svg
+++ b/cards/stack-dark.svg
@@ -6,89 +6,90 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="372" rx="16" fill="#0d1117" stroke="#20262e"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Languages</text>
-<line x1="101" y1="10" x2="822" y2="10" stroke="#1c222a"/>
+<line x1="101" y1="10" x2="822" y2="10" stroke="#222a33"/>
 <text x="18.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Kotlin</text>
-<rect x="118.0" y="37.0" width="554.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="118.0" y="37.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="118.0" y="37.0" width="374.8" height="9.0" rx="5" fill="url(#g_purple)"/>
 <text x="822.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">34 hrs 27 mins · 67.7%</text>
 <text x="18.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Markdown</text>
-<rect x="118.0" y="59.0" width="554.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="118.0" y="59.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="118.0" y="59.0" width="154.8" height="9.0" rx="5" fill="#3A82A8"/>
 <text x="822.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">14 hrs 14 mins · 27.9%</text>
 <text x="18.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">HTML</text>
-<rect x="118.0" y="81.0" width="554.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="118.0" y="81.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="118.0" y="81.0" width="13.2" height="9.0" rx="5" fill="#D97757"/>
 <text x="822.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">1 hr 12 mins · 2.4%</text>
 <text x="18.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">YAML</text>
-<rect x="118.0" y="103.0" width="554.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="118.0" y="103.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="118.0" y="103.0" width="5.8" height="9.0" rx="5" fill="#6E7681"/>
 <text x="822.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">32 mins · 1.1%</text>
 <text x="18.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Other</text>
-<rect x="118.0" y="125.0" width="554.0" height="9.0" rx="5" fill="#161b22"/>
+<rect x="118.0" y="125.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="118.0" y="125.0" width="3.8" height="9.0" rx="5" fill="#58A6FF"/>
 <text x="822.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">21 mins · 0.7%</text>
 <text x="18.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Editors</text>
-<line x1="84" y1="148" x2="407" y2="148" stroke="#1c222a"/>
+<line x1="84" y1="148" x2="407" y2="148" stroke="#222a33"/>
 <text x="18.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Claude Code</text>
-<rect x="108.0" y="175.0" width="251.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="108.0" y="175.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="108.0" y="175.0" width="247.4" height="8.0" rx="4" fill="url(#g_claude)"/>
 <text x="407.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">98.5%</text>
 <text x="18.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Warp</text>
-<rect x="108.0" y="199.0" width="251.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="108.0" y="199.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="108.0" y="199.0" width="1.6" height="8.0" rx="4" fill="#5b6470"/>
 <text x="407.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.6%</text>
 <text x="18.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">IntelliJ IDEA</text>
-<rect x="108.0" y="223.0" width="251.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="108.0" y="223.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="108.0" y="223.0" width="1.0" height="8.0" rx="4" fill="#5b6470"/>
 <text x="407.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
 <text x="18.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Obsidian</text>
-<rect x="108.0" y="247.0" width="251.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="108.0" y="247.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="108.0" y="247.0" width="1.0" height="8.0" rx="4" fill="#5b6470"/>
 <text x="407.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
 <text x="433.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Projects</text>
-<line x1="508" y1="148" x2="822" y2="148" stroke="#1c222a"/>
+<line x1="508" y1="148" x2="822" y2="148" stroke="#222a33"/>
 <text x="433.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">bare</text>
-<rect x="519.0" y="175.0" width="255.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="519.0" y="175.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="519.0" y="175.0" width="139.1" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="822.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">54.5%</text>
 <text x="433.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">miner</text>
-<rect x="519.0" y="199.0" width="255.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="519.0" y="199.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="519.0" y="199.0" width="101.3" height="8.0" rx="4" fill="url(#g_purple)"/>
 <text x="822.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">39.7%</text>
 <text x="433.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">a20****7</text>
-<rect x="519.0" y="223.0" width="255.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="519.0" y="223.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="519.0" y="223.0" width="5.8" height="8.0" rx="4" fill="#5b6470"/>
 <text x="822.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">2.3%</text>
 <text x="433.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">dynamic-xche</text>
-<rect x="519.0" y="247.0" width="255.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="519.0" y="247.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="519.0" y="247.0" width="3.5" height="8.0" rx="4" fill="#5b6470"/>
 <text x="822.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">1.4%</text>
 <text x="18.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Dependencies</text>
-<line x1="125" y1="280" x2="726" y2="280" stroke="#1c222a"/>
+<line x1="125" y1="280" x2="726" y2="280" stroke="#222a33"/>
 <text x="822.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">detected libraries</text>
 <text x="18.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">co****l</text>
-<rect x="168.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="168.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="168.0" y="307.0" width="46.2" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="407.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">24%</text>
 <text x="433.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">io.kotest</text>
-<rect x="583.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="583.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="583.0" y="307.0" width="32.8" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="822.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">17%</text>
 <text x="18.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">org.springframework</text>
-<rect x="168.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="168.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="168.0" y="331.0" width="22.2" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="407.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
 <text x="433.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">run.ravit</text>
-<rect x="583.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="583.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="583.0" y="331.0" width="20.6" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="822.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
 <text x="18.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">kotlinx.coroutines</text>
-<rect x="168.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="168.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="168.0" y="355.0" width="16.3" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="407.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">8%</text>
 <text x="433.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">com.fasterxml</text>
-<rect x="583.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#161b22"/>
+<rect x="583.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
 <rect x="583.0" y="355.0" width="10.3" height="8.0" rx="4" fill="url(#g_blue)"/>
 <text x="822.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">5%</text>
 </svg>

--- a/cards/stack-light.svg
+++ b/cards/stack-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="372" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Languages</text>
 <line x1="101" y1="10" x2="822" y2="10" stroke="#d8dee4"/>
 <text x="18.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Kotlin</text>

--- a/cards/week-dark.svg
+++ b/cards/week-dark.svg
@@ -6,55 +6,56 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="18.0" y="14.0" width="804.0" height="132.0" rx="14" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="1" y="6" width="838" height="270" rx="16" fill="#0d1117" stroke="#20262e"/>
+<rect x="18.0" y="14.0" width="804.0" height="132.0" rx="14" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="38.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#5b6470" text-anchor="start" letter-spacing="1.2" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
 <text x="38.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>
 <text x="120.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#8b949e" text-anchor="start">coding time</text>
 <text x="802.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">56h vs 46h</text>
 <text x="38.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Coding time</text>
 <text x="279.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#58A6FF"/>
-<rect x="38.0" y="104.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="38.0" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="38.0" y="104.0" width="199.8" height="6.0" rx="3" fill="#5b6470"/>
 <text x="38.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 56h</text>
 <text x="279.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 46h</text>
 <text x="299.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">AI lines</text>
 <text x="540.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 59%</text>
-<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#D97757"/>
-<rect x="299.3" y="104.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="299.3" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="299.3" y="104.0" width="151.5" height="6.0" rx="3" fill="#5b6470"/>
 <text x="299.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 49.9K</text>
 <text x="540.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 31.3K</text>
 <text x="560.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Tokens</text>
 <text x="802.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#A371F7"/>
-<rect x="560.7" y="104.0" width="241.3" height="6.0" rx="3" fill="#161b22"/>
+<rect x="560.7" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="560.7" y="104.0" width="199.6" height="6.0" rx="3" fill="#5b6470"/>
 <text x="560.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 3.32B</text>
 <text x="802.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 2.75B</text>
 <text x="18.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">AI Agents</text>
-<line x1="101" y1="164" x2="726" y2="164" stroke="#1c222a"/>
+<line x1="101" y1="164" x2="726" y2="164" stroke="#222a33"/>
 <text x="822.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">lines · est. cost</text>
-<rect x="18.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="18.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <rect x="36.0" y="206.0" width="18.0" height="18.0" rx="6" fill="#D97757"/>
 <text x="45.0" y="219.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">C</text>
 <text x="62.0" y="220.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#f0f6fc" text-anchor="start">Claude</text>
 <text x="389.0" y="220.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">$7,832</text>
 <text x="36.0" y="246.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">lines</text>
-<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="#161b22"/>
+<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="#1c222b"/>
 <rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="url(#g_claude)"/>
 <text x="389.0" y="245.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="end">40,056</text>
-<rect x="433.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#10161e" stroke="#20262e" stroke-width="1"/>
+<rect x="433.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
 <text x="451.0" y="216.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="600" fill="#5b6470" text-anchor="start" letter-spacing="1" style="text-transform:uppercase">MACHINES</text>
 <text x="451.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">20****7</text>
-<rect x="451.0" y="242.0" width="303.0" height="6.0" rx="3" fill="#161b22"/>
+<rect x="451.0" y="242.0" width="303.0" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="451.0" y="242.0" width="180.4" height="6.0" rx="3" fill="url(#g_blue)"/>
 <text x="804.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">60%</text>
 <text x="451.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">RAViT</text>
-<rect x="451.0" y="264.0" width="303.0" height="6.0" rx="3" fill="#161b22"/>
+<rect x="451.0" y="264.0" width="303.0" height="6.0" rx="3" fill="#1c222b"/>
 <rect x="451.0" y="264.0" width="122.6" height="6.0" rx="3" fill="#5b6470"/>
 <text x="804.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">40%</text>
 </svg>

--- a/cards/week-light.svg
+++ b/cards/week-light.svg
@@ -6,6 +6,7 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
+<rect x="1" y="6" width="838" height="270" rx="16" fill="#ffffff" stroke="#d0d7de"/>
 <rect x="18.0" y="14.0" width="804.0" height="132.0" rx="14" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
 <text x="38.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#9aa3ad" text-anchor="start" letter-spacing="1.2" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
 <text x="38.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>


### PR DESCRIPTION
## Summary
- 투명 배경이라 hero·week 밴드만 패널이 있고 header·rhythm·stack·heatmap은 페이지 바탕에 떠 보이던 비일관성 해결
- **6개 밴드 모두 테마 적응형 카드 배경** (dark `#0d1117` / light `#fff`) + 경계선, 위아래 6px 여백으로 스택 시 카드 간 간극
- `<picture>` 다크/라이트 전환 이점은 그대로 유지

## Test plan
- [x] 12개 밴드 XML 검증
- [x] dark/light 스택 미리보기 시각 확인 — 전 밴드 일관된 카드
- [ ] 병합 후 프로필에서 확인