### PR TITLE
refactor: 영역별 플랫 카드 재구성 + 바텀 패딩 정규화

### DIFF
--- a/.github/scripts/waka_card.py
+++ b/.github/scripts/waka_card.py
@@ -20,6 +20,11 @@ from waka_data import collect, WakaData
 WIDTH = 840
 PAD = 18
 INNER = WIDTH - PAD * 2
+PAD_IN = 18          # 카드 내부 패딩
+GAP = 14             # 영역 카드 세로 간격
+HGAP = 16            # 좌우 카드 간격
+TOP = 7              # 밴드 상/하 여백
+HALF = (INNER - HGAP) / 2
 
 SANS = "'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif"
 MONO = "'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace"
@@ -127,6 +132,14 @@ class Canvas:
         if filled > 0:
             self.rect(x, y, filled, height, fill, radius)
 
+    def card(self, x, y, width, height):
+        self.rect(x, y, width, height, self.theme.card_bg, radius=14, stroke=self.theme.card_stroke)
+
+    def ctitle(self, x, y, title, right=None, right_x=None):
+        self.text(x, y, title, 11, self.theme.blue, 600, MONO, spacing="1.3", upper=True)
+        if right is not None and right_x is not None:
+            self.text(right_x, y, right, 10, self.theme.mute, 500, MONO, anchor="end")
+
     def section(self, y, title, right=None, x=PAD, width=INNER):
         self.text(x, y, title, 12, self.theme.blue, 600, MONO, spacing="1.4", upper=True)
         title_end = x + 9 + len(title) * 8.2
@@ -167,25 +180,32 @@ def wrap(canvas: Canvas, height: float) -> str:
 
 def band_header(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    y = 34
-    canvas.rect(PAD, y - 14, 48, 48, "url(#g_blue)", radius=13)
-    canvas.text(PAD + 24, y + 16, "R", 21, "#fff", 700, SANS, anchor="middle")
-    canvas.text(PAD + 62, y + 6, "devRavit", 23, theme.foreground, 700, SANS, spacing="-0.2")
-    canvas.text(PAD + 62, y + 26, f"WakaTime · {data.range_text} · {data.total_text} coded",
+    h = 72
+    canvas.card(PAD, TOP, INNER, h)
+    ix = PAD + PAD_IN
+    av = 46
+    avy = TOP + (h - av) / 2
+    canvas.rect(ix, avy, av, av, "url(#g_blue)", radius=13)
+    canvas.text(ix + av / 2, avy + 30, "R", 20, "#fff", 700, SANS, anchor="middle")
+    tx = ix + av + 14
+    canvas.text(tx, TOP + 30, "devRavit", 22, theme.foreground, 700, SANS, spacing="-0.2")
+    canvas.text(tx, TOP + 49, f"WakaTime · {data.range_text} · {data.total_text} coded",
                 12, theme.mute, 500, MONO)
-    right = PAD + INNER
+    right = PAD + INNER - PAD_IN
 
     def badge(x, label, fill, border, dot=None, emoji=None):
         width = 24 + len(label) * 7.1 + (16 if dot or emoji else 0)
-        canvas.rect(x - width, y - 6, width, 26, fill, radius=13, stroke=border)
+        top = TOP + 13
+        canvas.rect(x - width, top, width, 26, fill, radius=13, stroke=border)
         cursor = x - width + 13
+        baseline = top + 17
         if dot:
-            canvas.add(f'<circle cx="{cursor}" cy="{y + 7:.0f}" r="3.5" fill="{dot}"/>')
+            canvas.add(f'<circle cx="{cursor}" cy="{top + 13:.0f}" r="3.5" fill="{dot}"/>')
             cursor += 11
         if emoji:
-            canvas.text(cursor - 2, y + 11, emoji, 12, theme.foreground, 400, SANS)
+            canvas.text(cursor - 2, baseline, emoji, 12, theme.foreground, 400, SANS)
             cursor += 16
-        canvas.text(cursor, y + 11, label, 11, theme.foreground2, 600, MONO)
+        canvas.text(cursor, baseline, label, 11, theme.foreground2, 600, MONO)
         return x - width - 9
 
     badge_bg = "#11243b" if theme.key == "dark" else "#dbeafe"
@@ -193,22 +213,19 @@ def band_header(canvas: Canvas, data: WakaData) -> float:
     nxt = badge(nxt, "Night Owl", theme.panel, theme.panel_stroke, emoji="🦉")
     streak_bg = "#2a1a10" if theme.key == "dark" else "#fbe9df"
     badge(nxt, f"{data.streak}d streak", streak_bg, CLAUDE, emoji="🔥")
-    canvas.text(right, y + 34, f"avg {data.daily_avg_text} / day", 11, theme.faint, 500, MONO, anchor="end")
-    return y + 48
+    canvas.text(right, TOP + 54, f"avg {data.daily_avg_text} / day", 11, theme.faint, 500, MONO, anchor="end")
+    return TOP + h
 
 
 def band_hero(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    y = 14
-    hero_h = 150
-    hero_bg = "#1a130f" if theme.key == "dark" else "#fbf1ea"
-    hero_stroke = "#3a2a20" if theme.key == "dark" else "#f0d9cb"
-    canvas.rect(PAD, y, INNER, hero_h, hero_bg, radius=16, stroke=hero_stroke)
-    cx, cy, r = PAD + 75, y + hero_h / 2, 52
+    y = TOP
+    hero_h = 132
+    # 히어로(AI 링)는 배경 없음 — 투명
+    cx, cy, r = PAD + PAD_IN + 52, y + hero_h / 2, 52
     circ = 2 * math.pi * r
     offset = circ * (1 - data.ai_coding_pct / 100.0)
-    ring_track = "#241a14" if theme.key == "dark" else "#f2ddd0"
-    canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="{ring_track}" stroke-width="13"/>')
+    canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="{theme.track}" stroke-width="13"/>')
     canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="url(#g_ring)" stroke-width="13" '
                f'stroke-linecap="round" stroke-dasharray="{circ:.1f}" stroke-dashoffset="{offset:.1f}" '
                f'transform="rotate(-90 {cx} {cy:.0f})"/>')
@@ -216,64 +233,67 @@ def band_hero(canvas: Canvas, data: WakaData) -> float:
                 anchor="middle", spacing="-1")
     canvas.text(cx, cy + 16, "% AI-DRIVEN", 9, CLAUDE2, 600, MONO, anchor="middle", spacing="1")
 
-    bx = PAD + 160
-    bw = INNER - 160 - 28
-    canvas.text(bx, y + 30, "거의 모든 코드를 Claude와 함께 작성했어요", 16, theme.foreground, 600, SANS)
+    bx = PAD + PAD_IN + 150
+    bright = PAD + INNER - PAD_IN
+    bw = bright - bx
+    canvas.text(bx, y + 28, "거의 모든 코드를 Claude와 함께 작성했어요", 16, theme.foreground, 600, SANS)
     total = max(1, data.ai_lines + data.human_lines)
     ai_pct = data.ai_lines / total * 100
     human_pct = data.human_lines / total * 100
-    row = y + 52
+    row = y + 54
     canvas.add(f'<circle cx="{bx + 4}" cy="{row - 4}" r="4" fill="{CLAUDE}"/>')
     canvas.text(bx + 16, row, "AI", 13, theme.sub, 500, MONO)
     canvas.text(bx + 42, row, fmt_count(data.ai_lines), 15, theme.foreground, 700, SANS)
-    canvas.text(bx + bw, row, f"{ai_pct:.0f}%", 13, theme.foreground2, 600, MONO, anchor="end")
+    canvas.text(bright, row, f"{ai_pct:.0f}%", 13, theme.foreground2, 600, MONO, anchor="end")
     canvas.bar(bx, row + 8, bw, 9, ai_pct, "url(#g_claude)", radius=5)
     row += 36
     canvas.add(f'<circle cx="{bx + 4}" cy="{row - 4}" r="4" fill="{GREEN}"/>')
     canvas.text(bx + 16, row, "Human", 13, theme.sub, 500, MONO)
     canvas.text(bx + 64, row, fmt_count(data.human_lines), 15, theme.foreground, 700, SANS)
-    canvas.text(bx + bw, row, f"{human_pct:.0f}%", 13, theme.mute, 600, MONO, anchor="end")
+    canvas.text(bright, row, f"{human_pct:.0f}%", 13, theme.mute, 600, MONO, anchor="end")
     canvas.bar(bx, row + 8, bw, 9, human_pct, GREEN, radius=5)
 
-    y += hero_h + 16
+    y += hero_h + GAP
     tiles = [
         (fmt_count(data.ai_lines), "AI line changes", None),
         (fmt_count(data.tokens_in), f"tokens in · {fmt_count(data.tokens_out)} out", "B"),
         (fmt_money(data.est_cost), "est. cost · 7 days", None),
         (f"{data.lines_per_prompt:.0f}", "lines / prompt", None),
     ]
-    tile_w = (INNER - 13 * 3) / 4
+    tile_gap = 12
+    tile_w = (INNER - tile_gap * 3) / 4
     for index, (value, label, suffix) in enumerate(tiles):
-        tx = PAD + index * (tile_w + 13)
-        canvas.rect(tx, y, tile_w, 70, theme.panel, radius=13, stroke=theme.panel_stroke)
-        canvas.text(tx + 16, y + 30, value, 25, theme.foreground, 700, SANS, spacing="-0.5")
+        tx = PAD + index * (tile_w + tile_gap)
+        canvas.card(tx, y, tile_w, 72)
+        canvas.text(tx + PAD_IN, y + 32, value, 25, theme.foreground, 700, SANS, spacing="-0.5")
         if suffix:
-            canvas.text(tx + 16 + len(value) * 15.5, y + 30, suffix, 16, theme.blue, 700, SANS)
-        canvas.text(tx + 16, y + 52, label, 11, theme.mute, 500, MONO)
-    return y + 70 + 6
+            canvas.text(tx + PAD_IN + len(value) * 15.5, y + 32, suffix, 16, theme.blue, 700, SANS)
+        canvas.text(tx + PAD_IN, y + 54, label, 11, theme.mute, 500, MONO)
+    return y + 72
 
 
 def band_week(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    y = 14
-    box_h = 132
-    canvas.rect(PAD, y, INNER, box_h, theme.panel, radius=14, stroke=theme.panel_stroke)
-    canvas.text(PAD + 20, y + 26, "THIS WEEK vs LAST WEEK", 11, theme.faint, 600, MONO, spacing="1.2", upper=True)
+    y = TOP
+    wow_h = 130
+    canvas.card(PAD, y, INNER, wow_h)
+    ix = PAD + PAD_IN
+    iright = PAD + INNER - PAD_IN
+    canvas.ctitle(ix, y + 24, "THIS WEEK vs LAST WEEK",
+                  right=f"{data.wow_time[0] / 3600:.0f}h vs {data.wow_time[1] / 3600:.0f}h", right_x=iright)
     delta, color = fmt_delta(data.wow_time[2], theme)
-    canvas.text(PAD + 20, y + 52, delta, 22, color, 700, SANS, spacing="-0.5")
-    canvas.text(PAD + 20 + len(delta) * 14 + 12, y + 52, "coding time", 12, theme.sub, 500, MONO)
-    canvas.text(PAD + INNER - 20, y + 26,
-                f"{data.wow_time[0] / 3600:.0f}h vs {data.wow_time[1] / 3600:.0f}h",
-                12, theme.mute, 500, MONO, anchor="end")
+    canvas.text(ix, y + 50, delta, 22, color, 700, SANS, spacing="-0.5")
+    canvas.text(ix + len(delta) * 14 + 12, y + 50, "coding time", 12, theme.sub, 500, MONO)
     rows = [
         ("Coding time", data.wow_time[0] / 3600, data.wow_time[1] / 3600, data.wow_time[2], "h", theme.blue),
         ("AI lines", data.wow_ai_lines[0], data.wow_ai_lines[1], data.wow_ai_lines[2], "#", CLAUDE),
         ("Tokens", data.wow_tokens[0], data.wow_tokens[1], data.wow_tokens[2], "t", PURPLE),
     ]
-    col_w = (INNER - 40 - 40) / 3
-    ry = y + 72
+    inner_w = INNER - 2 * PAD_IN
+    col_w = (inner_w - 2 * 20) / 3
+    ry = y + 74
     for index, (label, current, previous, percent, kind, color) in enumerate(rows):
-        rx = PAD + 20 + index * (col_w + 20)
+        rx = ix + index * (col_w + 20)
         current_text = f"{current:.0f}h" if kind == "h" else fmt_count(current)
         previous_text = f"{previous:.0f}h" if kind == "h" else fmt_count(previous)
         delta_text, delta_color = fmt_delta(percent, theme)
@@ -282,154 +302,192 @@ def band_week(canvas: Canvas, data: WakaData) -> float:
         canvas.bar(rx, ry + 8, col_w, 6, 100, color, radius=3)
         ratio = (previous / current * 100) if current else 0
         canvas.bar(rx, ry + 18, col_w, 6, ratio, theme.faint, radius=3)
-        canvas.text(rx, ry + 38, f"now {current_text}", 10, theme.mute, 500, MONO)
-        canvas.text(rx + col_w, ry + 38, f"prev {previous_text}", 10, theme.faint, 500, MONO, anchor="end")
+        canvas.text(rx, ry + 36, f"now {current_text}", 10, theme.mute, 500, MONO)
+        canvas.text(rx + col_w, ry + 36, f"prev {previous_text}", 10, theme.faint, 500, MONO, anchor="end")
 
-    y += box_h + 22
-    y = canvas.section(y, "AI Agents", "lines · est. cost")
-    half = (INNER - 26) / 2
+    y += wow_h + GAP
+    comp_h = 98
+    # AI Agent (left)
+    canvas.card(PAD, y, HALF, comp_h)
+    aix = PAD + PAD_IN
+    aright = PAD + HALF - PAD_IN
     name, lines, cost = (data.agents[0] if data.agents else ("Claude", data.ai_lines, data.est_cost))
-    canvas.rect(PAD, y, half, 78, theme.panel, radius=13, stroke=theme.panel_stroke)
-    canvas.rect(PAD + 18, y + 16, 18, 18, CLAUDE, radius=6)
-    canvas.text(PAD + 27, y + 29, name[0], 11, "#fff", 700, SANS, anchor="middle")
-    canvas.text(PAD + 44, y + 30, name, 14, theme.foreground, 600, SANS)
-    canvas.text(PAD + half - 18, y + 30, fmt_money(cost), 13, theme.foreground2, 600, MONO, anchor="end")
-    canvas.text(PAD + 18, y + 56, "lines", 10, theme.faint, 500, MONO)
-    canvas.bar(PAD + 56, y + 49, half - 56 - 80, 7, 100, "url(#g_claude)", radius=4)
-    canvas.text(PAD + half - 18, y + 55, f"{lines:,}", 11, theme.foreground2, 600, MONO, anchor="end")
-
-    mx = PAD + half + 26
-    canvas.rect(mx, y, half, 78, theme.panel, radius=13, stroke=theme.panel_stroke)
-    canvas.text(mx + 18, y + 26, "MACHINES", 10, theme.faint, 600, MONO, spacing="1", upper=True)
-    my = y + 46
+    canvas.ctitle(aix, y + 24, "AI AGENT", right="lines · cost", right_x=aright)
+    canvas.rect(aix, y + 38, 18, 18, CLAUDE, radius=6)
+    canvas.text(aix + 9, y + 51, name[0], 11, "#fff", 700, SANS, anchor="middle")
+    canvas.text(aix + 26, y + 52, name, 14, theme.foreground, 600, SANS)
+    canvas.text(aright, y + 52, fmt_money(cost), 13, theme.foreground2, 600, MONO, anchor="end")
+    canvas.text(aix, y + 78, "lines", 10, theme.faint, 500, MONO)
+    canvas.bar(aix + 40, y + 71, HALF - 2 * PAD_IN - 40 - 70, 7, 100, "url(#g_claude)", radius=4)
+    canvas.text(aright, y + 77, f"{lines:,}", 11, theme.foreground2, 600, MONO, anchor="end")
+    # Machines (right)
+    mx = PAD + HALF + HGAP
+    canvas.card(mx, y, HALF, comp_h)
+    mix = mx + PAD_IN
+    mright = mx + HALF - PAD_IN
+    canvas.ctitle(mix, y + 24, "MACHINES")
+    rowy = y + 50
     for index, (machine, percent, _) in enumerate(data.machines[:2]):
         label = machine.split(".")[0].replace("ui-MacBookPro", "")[:14]
-        canvas.text(mx + 18, my, label, 11, theme.foreground2, 500, MONO)
-        canvas.bar(mx + 18, my + 6, half - 36 - 50, 6, percent,
+        canvas.text(mix, rowy, label, 11, theme.foreground2, 500, MONO)
+        canvas.bar(mix + 84, rowy - 7, HALF - 2 * PAD_IN - 84 - 44, 6, percent,
                    "url(#g_blue)" if index == 0 else theme.faint, radius=3)
-        canvas.text(mx + half - 18, my, f"{percent:.0f}%", 11, theme.mute, 600, MONO, anchor="end")
-        my += 22
-    return y + 78
+        canvas.text(mright, rowy, f"{percent:.0f}%", 11, theme.mute, 600, MONO, anchor="end")
+        rowy += 24
+    return y + comp_h
 
 
 def band_rhythm(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    half = (INNER - 26) / 2
-    col_split = PAD + half + 26
-    top = 14
-    y2 = canvas.section(top, "When I code", data.peak_hour_text, x=PAD, width=half)
-    colors5 = ["#4C5FD5", "#E0A14B", canvas.theme.blue, "#A371F7", "#7C4DD0"]
-    canvas.add(f'<clipPath id="todclip"><rect x="{PAD}" y="{y2}" width="{half:.1f}" height="13" rx="6"/></clipPath>')
+    y = TOP
+    comp_h = 156
+    # When I code (left)
+    canvas.card(PAD, y, HALF, comp_h)
+    wix = PAD + PAD_IN
+    wright = PAD + HALF - PAD_IN
+    ww = HALF - 2 * PAD_IN
+    canvas.ctitle(wix, y + 24, "WHEN I CODE", right=data.peak_hour_text, right_x=wright)
+    colors5 = ["#4C5FD5", "#E0A14B", theme.blue, "#A371F7", "#7C4DD0"]
+    bar_y = y + 34
+    canvas.add(f'<clipPath id="todclip"><rect x="{wix}" y="{bar_y}" width="{ww:.1f}" height="12" rx="6"/></clipPath>')
     canvas.add('<g clip-path="url(#todclip)">')
-    cursor = PAD
+    cursor = wix
     for index, (_, _, _, percent) in enumerate(data.time_of_day):
-        width = half * percent / 100
-        canvas.rect(cursor, y2, width + 0.5, 13, colors5[index])
-        cursor += width
+        seg = ww * percent / 100
+        canvas.rect(cursor, bar_y, seg + 0.5, 12, colors5[index])
+        cursor += seg
     canvas.add('</g>')
-    line_y = y2 + 30
+    line_y = y + 62
     for index, (label, emoji, _, percent) in enumerate(data.time_of_day):
-        canvas.rect(PAD, line_y - 9, 9, 9, colors5[index], radius=3)
-        canvas.text(PAD + 16, line_y, f"{emoji} {label}", 12, theme.foreground2, 500, MONO)
-        canvas.text(PAD + half, line_y, f"{percent:.1f}%", 12, theme.foreground2, 600, MONO, anchor="end")
-        line_y += 20
-
-    canvas.section(top, "Weekday", f"peak {data.peak_weekday}요일", x=col_split, width=half)
+        canvas.rect(wix, line_y - 9, 9, 9, colors5[index], radius=3)
+        canvas.text(wix + 16, line_y, f"{emoji} {label}", 12, theme.foreground2, 500, MONO)
+        canvas.text(wright, line_y, f"{percent:.1f}%", 12, theme.foreground2, 600, MONO, anchor="end")
+        line_y += 18
+    # Weekday (right)
+    mx = PAD + HALF + HGAP
+    canvas.card(mx, y, HALF, comp_h)
+    mix = mx + PAD_IN
+    mright = mx + HALF - PAD_IN
+    canvas.ctitle(mix, y + 24, "WEEKDAY", right=f"peak {data.peak_weekday}요일", right_x=mright)
     weekday_max = max((w[1] for w in data.weekdays), default=1) or 1
-    bars_y = top + 22
-    bar_area = 110
+    bars_y = y + 40
+    bar_area = 78
     gap = 8
-    bar_w = (half - gap * 6) / 7
+    bw = (HALF - 2 * PAD_IN - gap * 6) / 7
     for index, (label, seconds, _, peak) in enumerate(data.weekdays):
         height = max(4, (seconds / weekday_max) * bar_area)
-        bx = col_split + index * (bar_w + gap)
+        bxx = mix + index * (bw + gap)
         by = bars_y + bar_area - height
         fill = "url(#g_peak)" if peak else theme.faint
-        canvas.rect(bx, by, bar_w, height, fill, radius=4)
-        canvas.text(bx + bar_w / 2, bars_y + bar_area + 16, label, 11,
+        canvas.rect(bxx, by, bw, height, fill, radius=4)
+        canvas.text(bxx + bw / 2, bars_y + bar_area + 16, label, 11,
                     theme.blue if peak else theme.mute, 600 if peak else 500, MONO, anchor="middle")
 
-    y = top + max(line_y - top, bars_y + bar_area + 16 - top) + 16
-    badge_bg = "#0e1722" if theme.key == "dark" else "#eef3f8"
-    canvas.rect(PAD, y, INNER, 34, badge_bg, radius=10, stroke=theme.panel_stroke)
-    canvas.text(PAD + 16, y + 22, "🏆 가장 생산적인 날", 12, theme.foreground2, 500, MONO)
-    canvas.text(PAD + INNER - 16, y + 22, data.best_day_text, 12, theme.blue, 600, MONO, anchor="end")
-    canvas.text(PAD + INNER / 2, y + 22,
+    y += comp_h + GAP
+    bd_h = 48
+    canvas.card(PAD, y, INNER, bd_h)
+    canvas.text(PAD + PAD_IN, y + 28, "🏆 가장 생산적인 날", 12, theme.foreground2, 500, MONO)
+    canvas.text(PAD + INNER - PAD_IN, y + 28, data.best_day_text, 12, theme.blue, 600, MONO, anchor="end")
+    canvas.text(PAD + INNER / 2, y + 28,
                 f"🔥 {data.streak}일 연속 · 최장 몰입 {data.longest_session_text}",
                 12, theme.mute, 500, MONO, anchor="middle")
-    return y + 34
+    return y + bd_h
 
 
 def band_stack(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    half = (INNER - 26) / 2
-    col_split = PAD + half + 26
-    y = canvas.section(14, "Languages")
+    y = TOP
+    # Languages (full width card)
+    lang_h = 46 + (len(data.languages) - 1) * 22 + 9 + 18
+    canvas.card(PAD, y, INNER, lang_h)
+    lix = PAD + PAD_IN
+    lright = PAD + INNER - PAD_IN
+    lw = INNER - 2 * PAD_IN
+    canvas.ctitle(lix, y + 24, "LANGUAGES")
+    ly = y + 46
     lang_colors = ["url(#g_purple)", "#3A82A8", CLAUDE, "#6E7681", theme.blue]
     for index, (name, percent, text) in enumerate(data.languages):
-        canvas.text(PAD, y + 9, name, 13, theme.foreground2, 500, MONO)
-        canvas.bar(PAD + 100, y + 1, INNER - 100 - 150, 9, percent, lang_colors[index % 5], radius=5)
-        canvas.text(PAD + INNER, y + 9, f"{text} · {percent:.1f}%", 12, theme.mute, 500, MONO, anchor="end")
-        y += 22
+        canvas.text(lix, ly + 9, name, 13, theme.foreground2, 500, MONO)
+        canvas.bar(lix + 96, ly + 1, lw - 96 - 150, 9, percent, lang_colors[index % 5], radius=5)
+        canvas.text(lright, ly + 9, f"{text} · {percent:.1f}%", 12, theme.mute, 500, MONO, anchor="end")
+        ly += 22
+    y += lang_h + GAP
 
-    y += 6
-    base = y
-    y2 = canvas.section(y, "Editors", x=PAD, width=half)
+    # Editors (left) + Projects (right)
+    comp_h = 48 + 3 * 24 + 8 + 18
+    canvas.card(PAD, y, HALF, comp_h)
+    eix = PAD + PAD_IN
+    eright = PAD + HALF - PAD_IN
+    canvas.ctitle(eix, y + 24, "EDITORS")
+    ey = y + 48
     for index, (name, percent, _) in enumerate(data.editors):
-        canvas.text(PAD, y2 + 8, name[:14], 12, theme.foreground2, 500, MONO)
-        canvas.bar(PAD + 90, y2 + 1, half - 90 - 48, 8, percent,
+        canvas.text(eix, ey + 8, name[:14], 12, theme.foreground2, 500, MONO)
+        canvas.bar(eix + 90, ey + 1, HALF - 2 * PAD_IN - 90 - 48, 8, percent,
                    "url(#g_claude)" if index == 0 else theme.faint, radius=4)
-        canvas.text(PAD + half, y2 + 8, f"{percent:.1f}%", 11, theme.mute, 600 if index == 0 else 500,
-                    MONO, anchor="end")
-        y2 += 24
-    yp = canvas.section(base, "Projects", x=col_split, width=half)
+        canvas.text(eright, ey + 8, f"{percent:.1f}%", 11, theme.mute, 600 if index == 0 else 500, MONO, anchor="end")
+        ey += 24
+    mx = PAD + HALF + HGAP
+    canvas.card(mx, y, HALF, comp_h)
+    pix = mx + PAD_IN
+    pright = mx + HALF - PAD_IN
+    canvas.ctitle(pix, y + 24, "PROJECTS")
+    py = y + 48
     project_colors = ["url(#g_blue)", "url(#g_purple)", theme.faint, theme.faint]
     for index, (name, percent, _) in enumerate(data.projects[:4]):
-        canvas.text(col_split, yp + 8, name[:12], 12, theme.foreground2, 500, MONO)
-        canvas.bar(col_split + 86, yp + 1, half - 86 - 48, 8, percent, project_colors[index], radius=4)
-        canvas.text(col_split + half, yp + 8, f"{percent:.1f}%", 11, theme.mute, 600 if index < 2 else 500,
-                    MONO, anchor="end")
-        yp += 24
-    y = max(y2, yp) + 14
+        canvas.text(pix, py + 8, name[:12], 12, theme.foreground2, 500, MONO)
+        canvas.bar(pix + 86, py + 1, HALF - 2 * PAD_IN - 86 - 48, 8, percent, project_colors[index], radius=4)
+        canvas.text(pright, py + 8, f"{percent:.1f}%", 11, theme.mute, 600 if index < 2 else 500, MONO, anchor="end")
+        py += 24
+    y += comp_h + GAP
 
-    y = canvas.section(y, "Dependencies", "detected libraries")
-    dep_w = (INNER - 26) / 2
+    # Dependencies (full width card)
+    dep_rows = (len(data.dependencies[:6]) + 1) // 2
+    dep_h = 48 + (dep_rows - 1) * 24 + 18
+    canvas.card(PAD, y, INNER, dep_h)
+    dix = PAD + PAD_IN
+    canvas.ctitle(dix, y + 24, "DEPENDENCIES", right="detected libraries", right_x=PAD + INNER - PAD_IN)
+    dep_col_w = (INNER - 2 * PAD_IN - HGAP) / 2
+    dy0 = y + 48
     for index, (name, percent, _) in enumerate(data.dependencies[:6]):
         column = index % 2
         rownum = index // 2
-        dx = PAD + column * (dep_w + 26)
-        dy = y + rownum * 24
-        canvas.text(dx, dy + 8, name[:20], 12, theme.foreground2, 500, MONO)
-        canvas.bar(dx + 150, dy + 1, dep_w - 150 - 44, 8, percent, "url(#g_blue)", radius=4)
-        canvas.text(dx + dep_w, dy + 8, f"{percent:.0f}%", 11, theme.mute, 500, MONO, anchor="end")
-    return y + ((len(data.dependencies[:6]) + 1) // 2) * 24 - 8
+        dx = dix + column * (dep_col_w + HGAP)
+        dy = dy0 + rownum * 24
+        canvas.text(dx, dy, name[:20], 12, theme.foreground2, 500, MONO)
+        canvas.bar(dx + 150, dy - 7, dep_col_w - 150 - 40, 8, percent, "url(#g_blue)", radius=4)
+        canvas.text(dx + dep_col_w, dy, f"{percent:.0f}%", 11, theme.mute, 500, MONO, anchor="end")
+    return y + dep_h
 
 
 def band_heatmap(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
-    y = canvas.section(14, "Last 30 days", f"{data.streak}일 연속 활동 🔥")
+    y = TOP
+    hix = PAD + PAD_IN
+    hright = PAD + INNER - PAD_IN
+    hw = INNER - 2 * PAD_IN
     count = len(data.heatmap)
     gap = 5
-    cell = (INNER - gap * (count - 1)) / count
+    cell = (hw - gap * (count - 1)) / count
+    hm_h = 104 + cell
+    canvas.card(PAD, y, INNER, hm_h)
+    canvas.ctitle(hix, y + 24, "LAST 30 DAYS", right=f"{data.streak}일 연속 활동 🔥", right_x=hright)
+    cells_y = y + 38
     for index, (_, _, level) in enumerate(data.heatmap):
-        hx = PAD + index * (cell + gap)
-        canvas.rect(hx, y, cell, cell, theme.heat[level], radius=3)
-    y += cell + 12
-    canvas.text(PAD, y + 8, "Less", 10, theme.faint, 500, MONO)
-    lx = PAD + 34
+        hx = hix + index * (cell + gap)
+        canvas.rect(hx, cells_y, cell, cell, theme.heat[level], radius=3)
+    legend_y = cells_y + cell + 14
+    canvas.text(hix, legend_y + 9, "Less", 10, theme.faint, 500, MONO)
+    lx = hix + 36
     for level in range(5):
-        canvas.rect(lx, y, 11, 11, theme.heat[level], radius=3)
+        canvas.rect(lx, legend_y + 1, 11, 11, theme.heat[level], radius=3)
         lx += 15
-    canvas.text(lx + 4, y + 8, "More", 10, theme.faint, 500, MONO)
-
-    y += 11 + 20
-    canvas.add(f'<line x1="{PAD}" y1="{y}" x2="{PAD + INNER}" y2="{y}" stroke="{theme.divider}"/>')
-    y += 18
+    canvas.text(lx + 4, legend_y + 9, "More", 10, theme.faint, 500, MONO)
+    foot_y = legend_y + 32
     owl = "저녁형" if data.late_night_pct < 25 else "새벽형"
-    canvas.text(PAD, y, f"저는 {owl} 인간이에요 🦉 · 피크 {data.peak_hour_text} · 평균 {data.daily_avg_text}/day",
+    canvas.text(hix, foot_y, f"저는 {owl} 인간이에요 🦉 · 피크 {data.peak_hour_text} · 평균 {data.daily_avg_text}/day",
                 11, theme.mute, 500, MONO)
-    canvas.text(PAD + INNER, y, "powered by WakaTime", 10, theme.faint, 500, MONO, anchor="end")
-    return y + 12
+    canvas.text(hright, foot_y, "powered by WakaTime", 10, theme.faint, 500, MONO, anchor="end")
+    return y + hm_h
 
 
 BANDS = [
@@ -445,14 +503,8 @@ BANDS = [
 def render_band(draw, data: WakaData, theme: Theme) -> str:
     canvas = Canvas(theme)
     gradients(canvas)
-    bg_index = len(canvas.parts)
     content_height = draw(canvas, data)
-    total = content_height + 14
-    # 밴드별 카드 배경 (테마 적응) — 위/아래 6px 투명 여백으로 스택 시 카드 간 간극
-    background = (f'<rect x="1" y="6" width="{WIDTH - 2}" height="{total - 12:.0f}" rx="16" '
-                 f'fill="{theme.card_bg}" stroke="{theme.card_stroke}"/>')
-    canvas.parts.insert(bg_index, background)
-    return wrap(canvas, total)
+    return wrap(canvas, content_height + TOP)
 
 
 def readme_snippet() -> str:

--- a/cards/header-dark.svg
+++ b/cards/header-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="96" viewBox="0 0 840 96" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="86" viewBox="0 0 840 86" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,19 +6,19 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="84" rx="16" fill="#0d1117" stroke="#20262e"/>
-<rect x="18.0" y="20.0" width="48.0" height="48.0" rx="13" fill="url(#g_blue)"/>
-<text x="42.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="21" font-weight="700" fill="#fff" text-anchor="middle">R</text>
-<text x="80.0" y="40.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="23" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.2">devRavit</text>
-<text x="80.0" y="60.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="start">WakaTime · last week · 50 hrs 35 mins coded</text>
-<rect x="718.1" y="28.0" width="103.9" height="26.0" rx="13" fill="#11243b" stroke="#58A6FF" stroke-width="1"/>
-<circle cx="731.1" cy="41" r="3.5" fill="#58A6FF"/>
-<text x="742.1" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">AI-Native</text>
-<rect x="605.2" y="28.0" width="103.9" height="26.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="616.2" y="45.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#f0f6fc" text-anchor="start">🦉</text>
-<text x="634.2" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">Night Owl</text>
-<rect x="485.2" y="28.0" width="111.0" height="26.0" rx="13" fill="#2a1a10" stroke="#D97757" stroke-width="1"/>
-<text x="496.2" y="45.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#f0f6fc" text-anchor="start">🔥</text>
-<text x="514.2" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">19d streak</text>
-<text x="822.0" y="68.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#5b6470" text-anchor="end">avg 10 hrs 7 mins / day</text>
+<rect x="18.0" y="7.0" width="804.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<rect x="36.0" y="20.0" width="46.0" height="46.0" rx="13" fill="url(#g_blue)"/>
+<text x="59.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="20" font-weight="700" fill="#fff" text-anchor="middle">R</text>
+<text x="96.0" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.2">devRavit</text>
+<text x="96.0" y="56.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="start">WakaTime · last week · 50 hrs 35 mins coded</text>
+<rect x="700.1" y="20.0" width="103.9" height="26.0" rx="13" fill="#11243b" stroke="#58A6FF" stroke-width="1"/>
+<circle cx="713.1" cy="33" r="3.5" fill="#58A6FF"/>
+<text x="724.1" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">AI-Native</text>
+<rect x="587.2" y="20.0" width="103.9" height="26.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
+<text x="598.2" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#f0f6fc" text-anchor="start">🦉</text>
+<text x="616.2" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">Night Owl</text>
+<rect x="467.2" y="20.0" width="111.0" height="26.0" rx="13" fill="#2a1a10" stroke="#D97757" stroke-width="1"/>
+<text x="478.2" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#f0f6fc" text-anchor="start">🔥</text>
+<text x="496.2" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="start">19d streak</text>
+<text x="804.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#5b6470" text-anchor="end">avg 10 hrs 7 mins / day</text>
 </svg>

--- a/cards/header-light.svg
+++ b/cards/header-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="96" viewBox="0 0 840 96" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="86" viewBox="0 0 840 86" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,19 +6,19 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="84" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<rect x="18.0" y="20.0" width="48.0" height="48.0" rx="13" fill="url(#g_blue)"/>
-<text x="42.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="21" font-weight="700" fill="#fff" text-anchor="middle">R</text>
-<text x="80.0" y="40.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="23" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.2">devRavit</text>
-<text x="80.0" y="60.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="start">WakaTime · last week · 50 hrs 35 mins coded</text>
-<rect x="718.1" y="28.0" width="103.9" height="26.0" rx="13" fill="#dbeafe" stroke="#3b82f6" stroke-width="1"/>
-<circle cx="731.1" cy="41" r="3.5" fill="#3b82f6"/>
-<text x="742.1" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">AI-Native</text>
-<rect x="605.2" y="28.0" width="103.9" height="26.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="616.2" y="45.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#1f2328" text-anchor="start">🦉</text>
-<text x="634.2" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">Night Owl</text>
-<rect x="485.2" y="28.0" width="111.0" height="26.0" rx="13" fill="#fbe9df" stroke="#D97757" stroke-width="1"/>
-<text x="496.2" y="45.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#1f2328" text-anchor="start">🔥</text>
-<text x="514.2" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">19d streak</text>
-<text x="822.0" y="68.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#9aa3ad" text-anchor="end">avg 10 hrs 7 mins / day</text>
+<rect x="18.0" y="7.0" width="804.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<rect x="36.0" y="20.0" width="46.0" height="46.0" rx="13" fill="url(#g_blue)"/>
+<text x="59.0" y="50.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="20" font-weight="700" fill="#fff" text-anchor="middle">R</text>
+<text x="96.0" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.2">devRavit</text>
+<text x="96.0" y="56.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="start">WakaTime · last week · 50 hrs 35 mins coded</text>
+<rect x="700.1" y="20.0" width="103.9" height="26.0" rx="13" fill="#dbeafe" stroke="#3b82f6" stroke-width="1"/>
+<circle cx="713.1" cy="33" r="3.5" fill="#3b82f6"/>
+<text x="724.1" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">AI-Native</text>
+<rect x="587.2" y="20.0" width="103.9" height="26.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
+<text x="598.2" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#1f2328" text-anchor="start">🦉</text>
+<text x="616.2" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">Night Owl</text>
+<rect x="467.2" y="20.0" width="111.0" height="26.0" rx="13" fill="#fbe9df" stroke="#D97757" stroke-width="1"/>
+<text x="478.2" y="37.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="12" font-weight="400" fill="#1f2328" text-anchor="start">🔥</text>
+<text x="496.2" y="37.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="start">19d streak</text>
+<text x="804.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#9aa3ad" text-anchor="end">avg 10 hrs 7 mins / day</text>
 </svg>

--- a/cards/heatmap-dark.svg
+++ b/cards/heatmap-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="145" viewBox="0 0 840 145" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="139" viewBox="0 0 840 139" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,48 +6,46 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="133" rx="16" fill="#0d1117" stroke="#20262e"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Last 30 days</text>
-<line x1="125" y1="10" x2="726" y2="10" stroke="#222a33"/>
-<text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">19일 연속 활동 🔥</text>
-<rect x="18.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
-<rect x="45.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#2f6fc0"/>
-<rect x="71.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="98.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="125.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="152.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
-<rect x="179.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
-<rect x="206.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#0d2d4a"/>
-<rect x="233.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#0d2d4a"/>
-<rect x="260.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
-<rect x="287.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="314.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="341.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="368.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#2f6fc0"/>
-<rect x="395.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="422.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="449.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="476.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="503.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#0d2d4a"/>
-<rect x="530.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#0d2d4a"/>
-<rect x="557.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#15487f"/>
-<rect x="584.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#58A6FF"/>
-<rect x="611.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#58A6FF"/>
-<rect x="638.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#58A6FF"/>
-<rect x="665.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#58A6FF"/>
-<rect x="692.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#2f6fc0"/>
-<rect x="719.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#0d2d4a"/>
-<rect x="746.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#2f6fc0"/>
-<rect x="773.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#58A6FF"/>
-<rect x="800.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#161b22"/>
-<text x="18.0" y="78.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">Less</text>
-<rect x="52.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#161b22"/>
-<rect x="67.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#0d2d4a"/>
-<rect x="82.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#15487f"/>
-<rect x="97.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#2f6fc0"/>
-<rect x="112.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#58A6FF"/>
-<text x="131.0" y="78.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">More</text>
-<line x1="18" y1="100.96666666666667" x2="822" y2="100.96666666666667" stroke="#222a33"/>
-<text x="18.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">저는 저녁형 인간이에요 🦉 · 피크 00:00–01:00 · 평균 10 hrs 7 mins/day</text>
-<text x="822.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">powered by WakaTime</text>
+<rect x="18.0" y="7.0" width="804.0" height="124.8" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">LAST 30 DAYS</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">19일 연속 활동 🔥</text>
+<rect x="36.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#161b22"/>
+<rect x="61.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#2f6fc0"/>
+<rect x="87.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="113.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="139.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="164.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#161b22"/>
+<rect x="190.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#161b22"/>
+<rect x="216.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#0d2d4a"/>
+<rect x="242.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#0d2d4a"/>
+<rect x="267.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#161b22"/>
+<rect x="293.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="319.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="345.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="371.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#2f6fc0"/>
+<rect x="396.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="422.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="448.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="474.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="499.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#0d2d4a"/>
+<rect x="525.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#0d2d4a"/>
+<rect x="551.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#15487f"/>
+<rect x="577.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#58A6FF"/>
+<rect x="602.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#58A6FF"/>
+<rect x="628.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#58A6FF"/>
+<rect x="654.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#58A6FF"/>
+<rect x="680.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#2f6fc0"/>
+<rect x="705.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#0d2d4a"/>
+<rect x="731.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#2f6fc0"/>
+<rect x="757.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#58A6FF"/>
+<rect x="783.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#161b22"/>
+<text x="36.0" y="88.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">Less</text>
+<rect x="72.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#161b22"/>
+<rect x="87.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#0d2d4a"/>
+<rect x="102.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#15487f"/>
+<rect x="117.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#2f6fc0"/>
+<rect x="132.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#58A6FF"/>
+<text x="151.0" y="88.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">More</text>
+<text x="36.0" y="111.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">저는 저녁형 인간이에요 🦉 · 피크 00:00–01:00 · 평균 10 hrs 7 mins/day</text>
+<text x="804.0" y="111.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">powered by WakaTime</text>
 </svg>

--- a/cards/heatmap-light.svg
+++ b/cards/heatmap-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="145" viewBox="0 0 840 145" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="139" viewBox="0 0 840 139" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,48 +6,46 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="133" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Last 30 days</text>
-<line x1="125" y1="10" x2="726" y2="10" stroke="#d8dee4"/>
-<text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">19일 연속 활동 🔥</text>
-<rect x="18.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#ebedf0"/>
-<rect x="45.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#4a8de0"/>
-<rect x="71.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="98.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="125.9" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="152.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#ebedf0"/>
-<rect x="179.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#ebedf0"/>
-<rect x="206.8" y="36.0" width="22.0" height="22.0" rx="3" fill="#bcd7f5"/>
-<rect x="233.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#bcd7f5"/>
-<rect x="260.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#ebedf0"/>
-<rect x="287.7" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="314.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="341.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="368.6" y="36.0" width="22.0" height="22.0" rx="3" fill="#4a8de0"/>
-<rect x="395.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="422.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="449.5" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="476.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="503.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#bcd7f5"/>
-<rect x="530.4" y="36.0" width="22.0" height="22.0" rx="3" fill="#bcd7f5"/>
-<rect x="557.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#7fb1ec"/>
-<rect x="584.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#1f6fdb"/>
-<rect x="611.3" y="36.0" width="22.0" height="22.0" rx="3" fill="#1f6fdb"/>
-<rect x="638.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#1f6fdb"/>
-<rect x="665.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#1f6fdb"/>
-<rect x="692.2" y="36.0" width="22.0" height="22.0" rx="3" fill="#4a8de0"/>
-<rect x="719.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#bcd7f5"/>
-<rect x="746.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#4a8de0"/>
-<rect x="773.1" y="36.0" width="22.0" height="22.0" rx="3" fill="#1f6fdb"/>
-<rect x="800.0" y="36.0" width="22.0" height="22.0" rx="3" fill="#ebedf0"/>
-<text x="18.0" y="78.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">Less</text>
-<rect x="52.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#ebedf0"/>
-<rect x="67.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#bcd7f5"/>
-<rect x="82.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#7fb1ec"/>
-<rect x="97.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#4a8de0"/>
-<rect x="112.0" y="70.0" width="11.0" height="11.0" rx="3" fill="#1f6fdb"/>
-<text x="131.0" y="78.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">More</text>
-<line x1="18" y1="100.96666666666667" x2="822" y2="100.96666666666667" stroke="#d8dee4"/>
-<text x="18.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">저는 저녁형 인간이에요 🦉 · 피크 00:00–01:00 · 평균 10 hrs 7 mins/day</text>
-<text x="822.0" y="119.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">powered by WakaTime</text>
+<rect x="18.0" y="7.0" width="804.0" height="124.8" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">LAST 30 DAYS</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">19일 연속 활동 🔥</text>
+<rect x="36.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#ebedf0"/>
+<rect x="61.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#4a8de0"/>
+<rect x="87.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="113.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="139.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="164.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#ebedf0"/>
+<rect x="190.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#ebedf0"/>
+<rect x="216.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#bcd7f5"/>
+<rect x="242.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#bcd7f5"/>
+<rect x="267.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#ebedf0"/>
+<rect x="293.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="319.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="345.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="371.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#4a8de0"/>
+<rect x="396.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="422.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="448.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="474.0" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="499.8" y="45.0" width="20.8" height="20.8" rx="3" fill="#bcd7f5"/>
+<rect x="525.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#bcd7f5"/>
+<rect x="551.3" y="45.0" width="20.8" height="20.8" rx="3" fill="#7fb1ec"/>
+<rect x="577.1" y="45.0" width="20.8" height="20.8" rx="3" fill="#1f6fdb"/>
+<rect x="602.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#1f6fdb"/>
+<rect x="628.6" y="45.0" width="20.8" height="20.8" rx="3" fill="#1f6fdb"/>
+<rect x="654.4" y="45.0" width="20.8" height="20.8" rx="3" fill="#1f6fdb"/>
+<rect x="680.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#4a8de0"/>
+<rect x="705.9" y="45.0" width="20.8" height="20.8" rx="3" fill="#bcd7f5"/>
+<rect x="731.7" y="45.0" width="20.8" height="20.8" rx="3" fill="#4a8de0"/>
+<rect x="757.5" y="45.0" width="20.8" height="20.8" rx="3" fill="#1f6fdb"/>
+<rect x="783.2" y="45.0" width="20.8" height="20.8" rx="3" fill="#ebedf0"/>
+<text x="36.0" y="88.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">Less</text>
+<rect x="72.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#ebedf0"/>
+<rect x="87.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#bcd7f5"/>
+<rect x="102.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#7fb1ec"/>
+<rect x="117.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#4a8de0"/>
+<rect x="132.0" y="80.8" width="11.0" height="11.0" rx="3" fill="#1f6fdb"/>
+<text x="151.0" y="88.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">More</text>
+<text x="36.0" y="111.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">저는 저녁형 인간이에요 🦉 · 피크 00:00–01:00 · 평균 10 hrs 7 mins/day</text>
+<text x="804.0" y="111.8" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">powered by WakaTime</text>
 </svg>

--- a/cards/hero-dark.svg
+++ b/cards/hero-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="270" viewBox="0 0 840 270" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="232" viewBox="0 0 840 232" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,36 +6,34 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="258" rx="16" fill="#0d1117" stroke="#20262e"/>
-<rect x="18.0" y="14.0" width="804.0" height="150.0" rx="16" fill="#1a130f" stroke="#3a2a20" stroke-width="1"/>
-<circle cx="93" cy="89" r="52" fill="none" stroke="#241a14" stroke-width="13"/>
-<circle cx="93" cy="89" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 93 89)"/>
-<text x="93.0" y="87.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#f0f6fc" text-anchor="middle" letter-spacing="-1">100</text>
-<text x="93.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>
-<text x="178.0" y="44.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#f0f6fc" text-anchor="start">거의 모든 코드를 Claude와 함께 작성했어요</text>
-<circle cx="182" cy="62" r="4" fill="#D97757"/>
-<text x="194.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">AI</text>
-<text x="220.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">50.8K</text>
-<text x="794.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">100%</text>
-<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="url(#g_claude)"/>
-<circle cx="182" cy="98" r="4" fill="#2EA043"/>
-<text x="194.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">Human</text>
-<text x="242.0" y="102.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">1</text>
-<text x="794.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#7d8590" text-anchor="end">0%</text>
-<rect x="178.0" y="110.0" width="616.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="178.0" y="110.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
-<rect x="18.0" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="34.0" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">50.8K</text>
-<text x="34.0" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">AI line changes</text>
-<rect x="222.2" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="238.2" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">3.71B</text>
-<text x="315.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#58A6FF" text-anchor="start">B</text>
-<text x="238.2" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">tokens in · 5.6M out</text>
-<rect x="426.5" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="442.5" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">$10,774</text>
-<text x="442.5" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">est. cost · 7 days</text>
-<rect x="630.8" y="180.0" width="191.2" height="70.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="646.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">89</text>
-<text x="646.8" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">lines / prompt</text>
+<circle cx="88" cy="73" r="52" fill="none" stroke="#1c222b" stroke-width="13"/>
+<circle cx="88" cy="73" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 88 73)"/>
+<text x="88.0" y="71.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#f0f6fc" text-anchor="middle" letter-spacing="-1">100</text>
+<text x="88.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>
+<text x="186.0" y="35.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#f0f6fc" text-anchor="start">거의 모든 코드를 Claude와 함께 작성했어요</text>
+<circle cx="190" cy="57" r="4" fill="#D97757"/>
+<text x="202.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">AI</text>
+<text x="228.0" y="61.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">50.8K</text>
+<text x="804.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">100%</text>
+<rect x="186.0" y="69.0" width="618.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="186.0" y="69.0" width="618.0" height="9.0" rx="5" fill="url(#g_claude)"/>
+<circle cx="190" cy="93" r="4" fill="#2EA043"/>
+<text x="202.0" y="97.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#8b949e" text-anchor="start">Human</text>
+<text x="250.0" y="97.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#f0f6fc" text-anchor="start">1</text>
+<text x="804.0" y="97.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#7d8590" text-anchor="end">0%</text>
+<rect x="186.0" y="105.0" width="618.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="186.0" y="105.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
+<rect x="18.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">50.8K</text>
+<text x="36.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">AI line changes</text>
+<rect x="222.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">3.71B</text>
+<text x="317.5" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#58A6FF" text-anchor="start">B</text>
+<text x="240.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">tokens in · 5.6M out</text>
+<rect x="426.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="444.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">$10,774</text>
+<text x="444.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">est. cost · 7 days</text>
+<rect x="630.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="648.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">89</text>
+<text x="648.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">lines / prompt</text>
 </svg>

--- a/cards/hero-light.svg
+++ b/cards/hero-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="270" viewBox="0 0 840 270" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="232" viewBox="0 0 840 232" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,36 +6,34 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="258" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<rect x="18.0" y="14.0" width="804.0" height="150.0" rx="16" fill="#fbf1ea" stroke="#f0d9cb" stroke-width="1"/>
-<circle cx="93" cy="89" r="52" fill="none" stroke="#f2ddd0" stroke-width="13"/>
-<circle cx="93" cy="89" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 93 89)"/>
-<text x="93.0" y="87.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#1f2328" text-anchor="middle" letter-spacing="-1">100</text>
-<text x="93.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>
-<text x="178.0" y="44.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#1f2328" text-anchor="start">거의 모든 코드를 Claude와 함께 작성했어요</text>
-<circle cx="182" cy="62" r="4" fill="#D97757"/>
-<text x="194.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#57606a" text-anchor="start">AI</text>
-<text x="220.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#1f2328" text-anchor="start">50.8K</text>
-<text x="794.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#3a424b" text-anchor="end">100%</text>
-<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="178.0" y="74.0" width="616.0" height="9.0" rx="5" fill="url(#g_claude)"/>
-<circle cx="182" cy="98" r="4" fill="#2EA043"/>
-<text x="194.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#57606a" text-anchor="start">Human</text>
-<text x="242.0" y="102.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#1f2328" text-anchor="start">1</text>
-<text x="794.0" y="102.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#6e7781" text-anchor="end">0%</text>
-<rect x="178.0" y="110.0" width="616.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="178.0" y="110.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
-<rect x="18.0" y="180.0" width="191.2" height="70.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="34.0" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">50.8K</text>
-<text x="34.0" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">AI line changes</text>
-<rect x="222.2" y="180.0" width="191.2" height="70.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="238.2" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">3.71B</text>
-<text x="315.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#3b82f6" text-anchor="start">B</text>
-<text x="238.2" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">tokens in · 5.6M out</text>
-<rect x="426.5" y="180.0" width="191.2" height="70.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="442.5" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">$10,774</text>
-<text x="442.5" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">est. cost · 7 days</text>
-<rect x="630.8" y="180.0" width="191.2" height="70.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="646.8" y="210.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">89</text>
-<text x="646.8" y="232.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">lines / prompt</text>
+<circle cx="88" cy="73" r="52" fill="none" stroke="#e7ebef" stroke-width="13"/>
+<circle cx="88" cy="73" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 88 73)"/>
+<text x="88.0" y="71.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#1f2328" text-anchor="middle" letter-spacing="-1">100</text>
+<text x="88.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>
+<text x="186.0" y="35.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="600" fill="#1f2328" text-anchor="start">거의 모든 코드를 Claude와 함께 작성했어요</text>
+<circle cx="190" cy="57" r="4" fill="#D97757"/>
+<text x="202.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#57606a" text-anchor="start">AI</text>
+<text x="228.0" y="61.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#1f2328" text-anchor="start">50.8K</text>
+<text x="804.0" y="61.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#3a424b" text-anchor="end">100%</text>
+<rect x="186.0" y="69.0" width="618.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="186.0" y="69.0" width="618.0" height="9.0" rx="5" fill="url(#g_claude)"/>
+<circle cx="190" cy="93" r="4" fill="#2EA043"/>
+<text x="202.0" y="97.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#57606a" text-anchor="start">Human</text>
+<text x="250.0" y="97.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#1f2328" text-anchor="start">1</text>
+<text x="804.0" y="97.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#6e7781" text-anchor="end">0%</text>
+<rect x="186.0" y="105.0" width="618.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="186.0" y="105.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
+<rect x="18.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">50.8K</text>
+<text x="36.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">AI line changes</text>
+<rect x="222.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">3.71B</text>
+<text x="317.5" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#3b82f6" text-anchor="start">B</text>
+<text x="240.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">tokens in · 5.6M out</text>
+<rect x="426.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="444.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">$10,774</text>
+<text x="444.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">est. cost · 7 days</text>
+<rect x="630.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="648.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">89</text>
+<text x="648.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">lines / prompt</text>
 </svg>

--- a/cards/rhythm-dark.svg
+++ b/cards/rhythm-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="230" viewBox="0 0 840 230" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="232" viewBox="0 0 840 232" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,52 +6,51 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="218" rx="16" fill="#0d1117" stroke="#20262e"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">When I code</text>
-<line x1="117" y1="10" x2="311" y2="10" stroke="#222a33"/>
-<text x="407.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">00:00–01:00</text>
-<clipPath id="todclip"><rect x="18" y="36" width="389.0" height="13" rx="6"/></clipPath>
+<rect x="18.0" y="7.0" width="394.0" height="156.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">WHEN I CODE</text>
+<text x="394.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">00:00–01:00</text>
+<clipPath id="todclip"><rect x="36" y="41" width="358.0" height="12" rx="6"/></clipPath>
 <g clip-path="url(#todclip)">
-<rect x="18.0" y="36.0" width="97.1" height="13.0" rx="0" fill="#4C5FD5"/>
-<rect x="114.6" y="36.0" width="81.9" height="13.0" rx="0" fill="#E0A14B"/>
-<rect x="196.0" y="36.0" width="158.7" height="13.0" rx="0" fill="#58A6FF"/>
-<rect x="354.1" y="36.0" width="21.3" height="13.0" rx="0" fill="#A371F7"/>
-<rect x="375.0" y="36.0" width="32.5" height="13.0" rx="0" fill="#7C4DD0"/>
+<rect x="36.0" y="41.0" width="89.4" height="12.0" rx="0" fill="#4C5FD5"/>
+<rect x="124.9" y="41.0" width="75.4" height="12.0" rx="0" fill="#E0A14B"/>
+<rect x="199.8" y="41.0" width="146.1" height="12.0" rx="0" fill="#58A6FF"/>
+<rect x="345.4" y="41.0" width="19.7" height="12.0" rx="0" fill="#A371F7"/>
+<rect x="364.5" y="41.0" width="30.0" height="12.0" rx="0" fill="#7C4DD0"/>
 </g>
-<rect x="18.0" y="57.0" width="9.0" height="9.0" rx="3" fill="#4C5FD5"/>
-<text x="34.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌙 새벽</text>
-<text x="407.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">24.8%</text>
-<rect x="18.0" y="77.0" width="9.0" height="9.0" rx="3" fill="#E0A14B"/>
-<text x="34.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌅 아침</text>
-<text x="407.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">20.9%</text>
-<rect x="18.0" y="97.0" width="9.0" height="9.0" rx="3" fill="#58A6FF"/>
-<text x="34.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">☀️ 낮</text>
-<text x="407.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">40.7%</text>
-<rect x="18.0" y="117.0" width="9.0" height="9.0" rx="3" fill="#A371F7"/>
-<text x="34.0" y="126.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌆 저녁</text>
-<text x="407.0" y="126.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">5.4%</text>
-<rect x="18.0" y="137.0" width="9.0" height="9.0" rx="3" fill="#7C4DD0"/>
-<text x="34.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌃 밤</text>
-<text x="407.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">8.2%</text>
-<text x="433.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Weekday</text>
-<line x1="499" y1="10" x2="726" y2="10" stroke="#222a33"/>
-<text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">peak 월요일</text>
-<rect x="433.0" y="36.0" width="48.7" height="110.0" rx="4" fill="url(#g_peak)"/>
-<text x="457.4" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="middle">월</text>
-<rect x="489.7" y="63.0" width="48.7" height="83.0" rx="4" fill="#5b6470"/>
-<text x="514.1" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">화</text>
-<rect x="546.4" y="64.5" width="48.7" height="81.5" rx="4" fill="#5b6470"/>
-<text x="570.8" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">수</text>
-<rect x="603.1" y="46.7" width="48.7" height="99.3" rx="4" fill="#5b6470"/>
-<text x="627.5" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">목</text>
-<rect x="659.9" y="78.6" width="48.7" height="67.4" rx="4" fill="#5b6470"/>
-<text x="684.2" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">금</text>
-<rect x="716.6" y="123.1" width="48.7" height="22.9" rx="4" fill="#5b6470"/>
-<text x="740.9" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">토</text>
-<rect x="773.3" y="75.1" width="48.7" height="70.9" rx="4" fill="#5b6470"/>
-<text x="797.6" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">일</text>
-<rect x="18.0" y="182.0" width="804.0" height="34.0" rx="10" fill="#0e1722" stroke="#283039" stroke-width="1"/>
-<text x="34.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🏆 가장 생산적인 날</text>
-<text x="806.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="end">수요일 · 13 hrs 8 mins</text>
-<text x="420.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="middle">🔥 19일 연속 · 최장 몰입 3h 9m</text>
+<rect x="36.0" y="60.0" width="9.0" height="9.0" rx="3" fill="#4C5FD5"/>
+<text x="52.0" y="69.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌙 새벽</text>
+<text x="394.0" y="69.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">24.8%</text>
+<rect x="36.0" y="78.0" width="9.0" height="9.0" rx="3" fill="#E0A14B"/>
+<text x="52.0" y="87.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌅 아침</text>
+<text x="394.0" y="87.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">20.9%</text>
+<rect x="36.0" y="96.0" width="9.0" height="9.0" rx="3" fill="#58A6FF"/>
+<text x="52.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">☀️ 낮</text>
+<text x="394.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">40.7%</text>
+<rect x="36.0" y="114.0" width="9.0" height="9.0" rx="3" fill="#A371F7"/>
+<text x="52.0" y="123.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌆 저녁</text>
+<text x="394.0" y="123.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">5.4%</text>
+<rect x="36.0" y="132.0" width="9.0" height="9.0" rx="3" fill="#7C4DD0"/>
+<text x="52.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🌃 밤</text>
+<text x="394.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#c9d1d9" text-anchor="end">8.2%</text>
+<rect x="428.0" y="7.0" width="394.0" height="156.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="446.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">WEEKDAY</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">peak 월요일</text>
+<rect x="446.0" y="47.0" width="44.3" height="78.0" rx="4" fill="url(#g_peak)"/>
+<text x="468.1" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="middle">월</text>
+<rect x="498.3" y="66.1" width="44.3" height="58.9" rx="4" fill="#5b6470"/>
+<text x="520.4" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">화</text>
+<rect x="550.6" y="67.2" width="44.3" height="57.8" rx="4" fill="#5b6470"/>
+<text x="572.7" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">수</text>
+<rect x="602.9" y="54.6" width="44.3" height="70.4" rx="4" fill="#5b6470"/>
+<text x="625.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">목</text>
+<rect x="655.1" y="77.2" width="44.3" height="47.8" rx="4" fill="#5b6470"/>
+<text x="677.3" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">금</text>
+<rect x="707.4" y="108.8" width="44.3" height="16.2" rx="4" fill="#5b6470"/>
+<text x="729.6" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">토</text>
+<rect x="759.7" y="74.7" width="44.3" height="50.3" rx="4" fill="#5b6470"/>
+<text x="781.9" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="middle">일</text>
+<rect x="18.0" y="177.0" width="804.0" height="48.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">🏆 가장 생산적인 날</text>
+<text x="804.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="end">수요일 · 13 hrs 8 mins</text>
+<text x="420.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="middle">🔥 19일 연속 · 최장 몰입 3h 9m</text>
 </svg>

--- a/cards/rhythm-light.svg
+++ b/cards/rhythm-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="230" viewBox="0 0 840 230" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="232" viewBox="0 0 840 232" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,52 +6,51 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="218" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">When I code</text>
-<line x1="117" y1="10" x2="311" y2="10" stroke="#d8dee4"/>
-<text x="407.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">00:00–01:00</text>
-<clipPath id="todclip"><rect x="18" y="36" width="389.0" height="13" rx="6"/></clipPath>
+<rect x="18.0" y="7.0" width="394.0" height="156.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">WHEN I CODE</text>
+<text x="394.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">00:00–01:00</text>
+<clipPath id="todclip"><rect x="36" y="41" width="358.0" height="12" rx="6"/></clipPath>
 <g clip-path="url(#todclip)">
-<rect x="18.0" y="36.0" width="97.1" height="13.0" rx="0" fill="#4C5FD5"/>
-<rect x="114.6" y="36.0" width="81.9" height="13.0" rx="0" fill="#E0A14B"/>
-<rect x="196.0" y="36.0" width="158.7" height="13.0" rx="0" fill="#3b82f6"/>
-<rect x="354.1" y="36.0" width="21.3" height="13.0" rx="0" fill="#A371F7"/>
-<rect x="375.0" y="36.0" width="32.5" height="13.0" rx="0" fill="#7C4DD0"/>
+<rect x="36.0" y="41.0" width="89.4" height="12.0" rx="0" fill="#4C5FD5"/>
+<rect x="124.9" y="41.0" width="75.4" height="12.0" rx="0" fill="#E0A14B"/>
+<rect x="199.8" y="41.0" width="146.1" height="12.0" rx="0" fill="#3b82f6"/>
+<rect x="345.4" y="41.0" width="19.7" height="12.0" rx="0" fill="#A371F7"/>
+<rect x="364.5" y="41.0" width="30.0" height="12.0" rx="0" fill="#7C4DD0"/>
 </g>
-<rect x="18.0" y="57.0" width="9.0" height="9.0" rx="3" fill="#4C5FD5"/>
-<text x="34.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌙 새벽</text>
-<text x="407.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">24.8%</text>
-<rect x="18.0" y="77.0" width="9.0" height="9.0" rx="3" fill="#E0A14B"/>
-<text x="34.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌅 아침</text>
-<text x="407.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">20.9%</text>
-<rect x="18.0" y="97.0" width="9.0" height="9.0" rx="3" fill="#3b82f6"/>
-<text x="34.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">☀️ 낮</text>
-<text x="407.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">40.7%</text>
-<rect x="18.0" y="117.0" width="9.0" height="9.0" rx="3" fill="#A371F7"/>
-<text x="34.0" y="126.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌆 저녁</text>
-<text x="407.0" y="126.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">5.4%</text>
-<rect x="18.0" y="137.0" width="9.0" height="9.0" rx="3" fill="#7C4DD0"/>
-<text x="34.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌃 밤</text>
-<text x="407.0" y="146.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">8.2%</text>
-<text x="433.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Weekday</text>
-<line x1="499" y1="10" x2="726" y2="10" stroke="#d8dee4"/>
-<text x="822.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">peak 월요일</text>
-<rect x="433.0" y="36.0" width="48.7" height="110.0" rx="4" fill="url(#g_peak)"/>
-<text x="457.4" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="middle">월</text>
-<rect x="489.7" y="63.0" width="48.7" height="83.0" rx="4" fill="#9aa3ad"/>
-<text x="514.1" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">화</text>
-<rect x="546.4" y="64.5" width="48.7" height="81.5" rx="4" fill="#9aa3ad"/>
-<text x="570.8" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">수</text>
-<rect x="603.1" y="46.7" width="48.7" height="99.3" rx="4" fill="#9aa3ad"/>
-<text x="627.5" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">목</text>
-<rect x="659.9" y="78.6" width="48.7" height="67.4" rx="4" fill="#9aa3ad"/>
-<text x="684.2" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">금</text>
-<rect x="716.6" y="123.1" width="48.7" height="22.9" rx="4" fill="#9aa3ad"/>
-<text x="740.9" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">토</text>
-<rect x="773.3" y="75.1" width="48.7" height="70.9" rx="4" fill="#9aa3ad"/>
-<text x="797.6" y="162.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">일</text>
-<rect x="18.0" y="182.0" width="804.0" height="34.0" rx="10" fill="#eef3f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="34.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🏆 가장 생산적인 날</text>
-<text x="806.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="end">수요일 · 13 hrs 8 mins</text>
-<text x="420.0" y="204.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="middle">🔥 19일 연속 · 최장 몰입 3h 9m</text>
+<rect x="36.0" y="60.0" width="9.0" height="9.0" rx="3" fill="#4C5FD5"/>
+<text x="52.0" y="69.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌙 새벽</text>
+<text x="394.0" y="69.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">24.8%</text>
+<rect x="36.0" y="78.0" width="9.0" height="9.0" rx="3" fill="#E0A14B"/>
+<text x="52.0" y="87.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌅 아침</text>
+<text x="394.0" y="87.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">20.9%</text>
+<rect x="36.0" y="96.0" width="9.0" height="9.0" rx="3" fill="#3b82f6"/>
+<text x="52.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">☀️ 낮</text>
+<text x="394.0" y="105.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">40.7%</text>
+<rect x="36.0" y="114.0" width="9.0" height="9.0" rx="3" fill="#A371F7"/>
+<text x="52.0" y="123.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌆 저녁</text>
+<text x="394.0" y="123.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">5.4%</text>
+<rect x="36.0" y="132.0" width="9.0" height="9.0" rx="3" fill="#7C4DD0"/>
+<text x="52.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🌃 밤</text>
+<text x="394.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3a424b" text-anchor="end">8.2%</text>
+<rect x="428.0" y="7.0" width="394.0" height="156.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="446.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">WEEKDAY</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">peak 월요일</text>
+<rect x="446.0" y="47.0" width="44.3" height="78.0" rx="4" fill="url(#g_peak)"/>
+<text x="468.1" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="middle">월</text>
+<rect x="498.3" y="66.1" width="44.3" height="58.9" rx="4" fill="#9aa3ad"/>
+<text x="520.4" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">화</text>
+<rect x="550.6" y="67.2" width="44.3" height="57.8" rx="4" fill="#9aa3ad"/>
+<text x="572.7" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">수</text>
+<rect x="602.9" y="54.6" width="44.3" height="70.4" rx="4" fill="#9aa3ad"/>
+<text x="625.0" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">목</text>
+<rect x="655.1" y="77.2" width="44.3" height="47.8" rx="4" fill="#9aa3ad"/>
+<text x="677.3" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">금</text>
+<rect x="707.4" y="108.8" width="44.3" height="16.2" rx="4" fill="#9aa3ad"/>
+<text x="729.6" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">토</text>
+<rect x="759.7" y="74.7" width="44.3" height="50.3" rx="4" fill="#9aa3ad"/>
+<text x="781.9" y="141.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="middle">일</text>
+<rect x="18.0" y="177.0" width="804.0" height="48.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">🏆 가장 생산적인 날</text>
+<text x="804.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="end">수요일 · 13 hrs 8 mins</text>
+<text x="420.0" y="205.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="middle">🔥 19일 연속 · 최장 몰입 3h 9m</text>
 </svg>

--- a/cards/stack-dark.svg
+++ b/cards/stack-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="384" viewBox="0 0 840 384" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="463" viewBox="0 0 840 463" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,90 +6,89 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="372" rx="16" fill="#0d1117" stroke="#20262e"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Languages</text>
-<line x1="101" y1="10" x2="822" y2="10" stroke="#222a33"/>
-<text x="18.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Kotlin</text>
-<rect x="118.0" y="37.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="118.0" y="37.0" width="374.8" height="9.0" rx="5" fill="url(#g_purple)"/>
-<text x="822.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">34 hrs 27 mins · 67.7%</text>
-<text x="18.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Markdown</text>
-<rect x="118.0" y="59.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="118.0" y="59.0" width="154.8" height="9.0" rx="5" fill="#3A82A8"/>
-<text x="822.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">14 hrs 14 mins · 27.9%</text>
-<text x="18.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">HTML</text>
-<rect x="118.0" y="81.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="118.0" y="81.0" width="13.2" height="9.0" rx="5" fill="#D97757"/>
-<text x="822.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">1 hr 12 mins · 2.4%</text>
-<text x="18.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">YAML</text>
-<rect x="118.0" y="103.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="118.0" y="103.0" width="5.8" height="9.0" rx="5" fill="#6E7681"/>
-<text x="822.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">32 mins · 1.1%</text>
-<text x="18.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Other</text>
-<rect x="118.0" y="125.0" width="554.0" height="9.0" rx="5" fill="#1c222b"/>
-<rect x="118.0" y="125.0" width="3.8" height="9.0" rx="5" fill="#58A6FF"/>
-<text x="822.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">21 mins · 0.7%</text>
-<text x="18.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Editors</text>
-<line x1="84" y1="148" x2="407" y2="148" stroke="#222a33"/>
-<text x="18.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Claude Code</text>
-<rect x="108.0" y="175.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="108.0" y="175.0" width="247.4" height="8.0" rx="4" fill="url(#g_claude)"/>
-<text x="407.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">98.5%</text>
-<text x="18.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Warp</text>
-<rect x="108.0" y="199.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="108.0" y="199.0" width="1.6" height="8.0" rx="4" fill="#5b6470"/>
-<text x="407.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.6%</text>
-<text x="18.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">IntelliJ IDEA</text>
-<rect x="108.0" y="223.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="108.0" y="223.0" width="1.0" height="8.0" rx="4" fill="#5b6470"/>
-<text x="407.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
-<text x="18.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Obsidian</text>
-<rect x="108.0" y="247.0" width="251.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="108.0" y="247.0" width="1.0" height="8.0" rx="4" fill="#5b6470"/>
-<text x="407.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
-<text x="433.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Projects</text>
-<line x1="508" y1="148" x2="822" y2="148" stroke="#222a33"/>
-<text x="433.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">bare</text>
-<rect x="519.0" y="175.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="519.0" y="175.0" width="139.1" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">54.5%</text>
-<text x="433.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">miner</text>
-<rect x="519.0" y="199.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="519.0" y="199.0" width="101.3" height="8.0" rx="4" fill="url(#g_purple)"/>
-<text x="822.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">39.7%</text>
-<text x="433.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">a20****7</text>
-<rect x="519.0" y="223.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="519.0" y="223.0" width="5.8" height="8.0" rx="4" fill="#5b6470"/>
-<text x="822.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">2.3%</text>
-<text x="433.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">dynamic-xche</text>
-<rect x="519.0" y="247.0" width="255.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="519.0" y="247.0" width="3.5" height="8.0" rx="4" fill="#5b6470"/>
-<text x="822.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">1.4%</text>
-<text x="18.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Dependencies</text>
-<line x1="125" y1="280" x2="726" y2="280" stroke="#222a33"/>
-<text x="822.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">detected libraries</text>
-<text x="18.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">co****l</text>
-<rect x="168.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="168.0" y="307.0" width="46.2" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">24%</text>
-<text x="433.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">io.kotest</text>
-<rect x="583.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="583.0" y="307.0" width="32.8" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">17%</text>
-<text x="18.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">org.springframework</text>
-<rect x="168.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="168.0" y="331.0" width="22.2" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
-<text x="433.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">run.ravit</text>
-<rect x="583.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="583.0" y="331.0" width="20.6" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
-<text x="18.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">kotlinx.coroutines</text>
-<rect x="168.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="168.0" y="355.0" width="16.3" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">8%</text>
-<text x="433.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">com.fasterxml</text>
-<rect x="583.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#1c222b"/>
-<rect x="583.0" y="355.0" width="10.3" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">5%</text>
+<rect x="18.0" y="7.0" width="804.0" height="161.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">LANGUAGES</text>
+<text x="36.0" y="62.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Kotlin</text>
+<rect x="132.0" y="54.0" width="522.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="132.0" y="54.0" width="353.2" height="9.0" rx="5" fill="url(#g_purple)"/>
+<text x="804.0" y="62.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">34 hrs 27 mins · 67.7%</text>
+<text x="36.0" y="84.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Markdown</text>
+<rect x="132.0" y="76.0" width="522.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="132.0" y="76.0" width="145.9" height="9.0" rx="5" fill="#3A82A8"/>
+<text x="804.0" y="84.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">14 hrs 14 mins · 27.9%</text>
+<text x="36.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">HTML</text>
+<rect x="132.0" y="98.0" width="522.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="132.0" y="98.0" width="12.4" height="9.0" rx="5" fill="#D97757"/>
+<text x="804.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">1 hr 12 mins · 2.4%</text>
+<text x="36.0" y="128.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">YAML</text>
+<rect x="132.0" y="120.0" width="522.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="132.0" y="120.0" width="5.5" height="9.0" rx="5" fill="#6E7681"/>
+<text x="804.0" y="128.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">32 mins · 1.1%</text>
+<text x="36.0" y="150.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#c9d1d9" text-anchor="start">Other</text>
+<rect x="132.0" y="142.0" width="522.0" height="9.0" rx="5" fill="#1c222b"/>
+<rect x="132.0" y="142.0" width="3.6" height="9.0" rx="5" fill="#58A6FF"/>
+<text x="804.0" y="150.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">21 mins · 0.7%</text>
+<rect x="18.0" y="182.0" width="394.0" height="146.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">EDITORS</text>
+<text x="36.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Claude Code</text>
+<rect x="126.0" y="231.0" width="220.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="126.0" y="231.0" width="216.8" height="8.0" rx="4" fill="url(#g_claude)"/>
+<text x="394.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">98.5%</text>
+<text x="36.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Warp</text>
+<rect x="126.0" y="255.0" width="220.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="126.0" y="255.0" width="1.4" height="8.0" rx="4" fill="#5b6470"/>
+<text x="394.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.6%</text>
+<text x="36.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">IntelliJ IDEA</text>
+<rect x="126.0" y="279.0" width="220.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="126.0" y="279.0" width="0.9" height="8.0" rx="4" fill="#5b6470"/>
+<text x="394.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
+<text x="36.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">Obsidian</text>
+<rect x="126.0" y="303.0" width="220.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="126.0" y="303.0" width="0.9" height="8.0" rx="4" fill="#5b6470"/>
+<text x="394.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">0.4%</text>
+<rect x="428.0" y="182.0" width="394.0" height="146.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="446.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">PROJECTS</text>
+<text x="446.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">bare</text>
+<rect x="532.0" y="231.0" width="224.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="532.0" y="231.0" width="122.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">54.5%</text>
+<text x="446.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">miner</text>
+<rect x="532.0" y="255.0" width="224.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="532.0" y="255.0" width="89.0" height="8.0" rx="4" fill="url(#g_purple)"/>
+<text x="804.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">39.7%</text>
+<text x="446.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">a20****7</text>
+<rect x="532.0" y="279.0" width="224.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="532.0" y="279.0" width="5.1" height="8.0" rx="4" fill="#5b6470"/>
+<text x="804.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">2.3%</text>
+<text x="446.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">dynamic-xche</text>
+<rect x="532.0" y="303.0" width="224.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="532.0" y="303.0" width="3.0" height="8.0" rx="4" fill="#5b6470"/>
+<text x="804.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">1.4%</text>
+<rect x="18.0" y="342.0" width="804.0" height="114.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="366.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">DEPENDENCIES</text>
+<text x="804.0" y="366.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">detected libraries</text>
+<text x="36.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">co****l</text>
+<rect x="186.0" y="383.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="186.0" y="383.0" width="44.0" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">24%</text>
+<text x="428.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">io.kotest</text>
+<rect x="578.0" y="383.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="578.0" y="383.0" width="31.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">17%</text>
+<text x="36.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">org.springframework</text>
+<rect x="186.0" y="407.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="186.0" y="407.0" width="21.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
+<text x="428.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">run.ravit</text>
+<rect x="578.0" y="407.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="578.0" y="407.0" width="19.6" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">11%</text>
+<text x="36.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">kotlinx.coroutines</text>
+<rect x="186.0" y="431.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="186.0" y="431.0" width="15.6" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">8%</text>
+<text x="428.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#c9d1d9" text-anchor="start">com.fasterxml</text>
+<rect x="578.0" y="431.0" width="186.0" height="8.0" rx="4" fill="#1c222b"/>
+<rect x="578.0" y="431.0" width="9.9" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">5%</text>
 </svg>

--- a/cards/stack-light.svg
+++ b/cards/stack-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="384" viewBox="0 0 840 384" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="463" viewBox="0 0 840 463" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,90 +6,89 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="372" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<text x="18.0" y="14.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Languages</text>
-<line x1="101" y1="10" x2="822" y2="10" stroke="#d8dee4"/>
-<text x="18.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Kotlin</text>
-<rect x="118.0" y="37.0" width="554.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="118.0" y="37.0" width="374.8" height="9.0" rx="5" fill="url(#g_purple)"/>
-<text x="822.0" y="45.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">34 hrs 27 mins · 67.7%</text>
-<text x="18.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Markdown</text>
-<rect x="118.0" y="59.0" width="554.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="118.0" y="59.0" width="154.8" height="9.0" rx="5" fill="#3A82A8"/>
-<text x="822.0" y="67.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">14 hrs 14 mins · 27.9%</text>
-<text x="18.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">HTML</text>
-<rect x="118.0" y="81.0" width="554.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="118.0" y="81.0" width="13.2" height="9.0" rx="5" fill="#D97757"/>
-<text x="822.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">1 hr 12 mins · 2.4%</text>
-<text x="18.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">YAML</text>
-<rect x="118.0" y="103.0" width="554.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="118.0" y="103.0" width="5.8" height="9.0" rx="5" fill="#6E7681"/>
-<text x="822.0" y="111.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">32 mins · 1.1%</text>
-<text x="18.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Other</text>
-<rect x="118.0" y="125.0" width="554.0" height="9.0" rx="5" fill="#e7ebef"/>
-<rect x="118.0" y="125.0" width="3.8" height="9.0" rx="5" fill="#3b82f6"/>
-<text x="822.0" y="133.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">21 mins · 0.7%</text>
-<text x="18.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Editors</text>
-<line x1="84" y1="148" x2="407" y2="148" stroke="#d8dee4"/>
-<text x="18.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Claude Code</text>
-<rect x="108.0" y="175.0" width="251.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="108.0" y="175.0" width="247.4" height="8.0" rx="4" fill="url(#g_claude)"/>
-<text x="407.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">98.5%</text>
-<text x="18.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Warp</text>
-<rect x="108.0" y="199.0" width="251.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="108.0" y="199.0" width="1.6" height="8.0" rx="4" fill="#9aa3ad"/>
-<text x="407.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.6%</text>
-<text x="18.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">IntelliJ IDEA</text>
-<rect x="108.0" y="223.0" width="251.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="108.0" y="223.0" width="1.0" height="8.0" rx="4" fill="#9aa3ad"/>
-<text x="407.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.4%</text>
-<text x="18.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Obsidian</text>
-<rect x="108.0" y="247.0" width="251.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="108.0" y="247.0" width="1.0" height="8.0" rx="4" fill="#9aa3ad"/>
-<text x="407.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.4%</text>
-<text x="433.0" y="152.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Projects</text>
-<line x1="508" y1="148" x2="822" y2="148" stroke="#d8dee4"/>
-<text x="433.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">bare</text>
-<rect x="519.0" y="175.0" width="255.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="519.0" y="175.0" width="139.1" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="182.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">54.5%</text>
-<text x="433.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">miner</text>
-<rect x="519.0" y="199.0" width="255.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="519.0" y="199.0" width="101.3" height="8.0" rx="4" fill="url(#g_purple)"/>
-<text x="822.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">39.7%</text>
-<text x="433.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">a20****7</text>
-<rect x="519.0" y="223.0" width="255.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="519.0" y="223.0" width="5.8" height="8.0" rx="4" fill="#9aa3ad"/>
-<text x="822.0" y="230.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">2.3%</text>
-<text x="433.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">dynamic-xche</text>
-<rect x="519.0" y="247.0" width="255.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="519.0" y="247.0" width="3.5" height="8.0" rx="4" fill="#9aa3ad"/>
-<text x="822.0" y="254.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">1.4%</text>
-<text x="18.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">Dependencies</text>
-<line x1="125" y1="280" x2="726" y2="280" stroke="#d8dee4"/>
-<text x="822.0" y="284.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">detected libraries</text>
-<text x="18.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">co****l</text>
-<rect x="168.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="168.0" y="307.0" width="46.2" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">24%</text>
-<text x="433.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">io.kotest</text>
-<rect x="583.0" y="307.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="583.0" y="307.0" width="32.8" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="314.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">17%</text>
-<text x="18.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">org.springframework</text>
-<rect x="168.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="168.0" y="331.0" width="22.2" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">11%</text>
-<text x="433.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">run.ravit</text>
-<rect x="583.0" y="331.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="583.0" y="331.0" width="20.6" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="338.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">11%</text>
-<text x="18.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">kotlinx.coroutines</text>
-<rect x="168.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="168.0" y="355.0" width="16.3" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="407.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">8%</text>
-<text x="433.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">com.fasterxml</text>
-<rect x="583.0" y="355.0" width="195.0" height="8.0" rx="4" fill="#e7ebef"/>
-<rect x="583.0" y="355.0" width="10.3" height="8.0" rx="4" fill="url(#g_blue)"/>
-<text x="822.0" y="362.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">5%</text>
+<rect x="18.0" y="7.0" width="804.0" height="161.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">LANGUAGES</text>
+<text x="36.0" y="62.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Kotlin</text>
+<rect x="132.0" y="54.0" width="522.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="132.0" y="54.0" width="353.2" height="9.0" rx="5" fill="url(#g_purple)"/>
+<text x="804.0" y="62.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">34 hrs 27 mins · 67.7%</text>
+<text x="36.0" y="84.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Markdown</text>
+<rect x="132.0" y="76.0" width="522.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="132.0" y="76.0" width="145.9" height="9.0" rx="5" fill="#3A82A8"/>
+<text x="804.0" y="84.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">14 hrs 14 mins · 27.9%</text>
+<text x="36.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">HTML</text>
+<rect x="132.0" y="98.0" width="522.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="132.0" y="98.0" width="12.4" height="9.0" rx="5" fill="#D97757"/>
+<text x="804.0" y="106.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">1 hr 12 mins · 2.4%</text>
+<text x="36.0" y="128.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">YAML</text>
+<rect x="132.0" y="120.0" width="522.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="132.0" y="120.0" width="5.5" height="9.0" rx="5" fill="#6E7681"/>
+<text x="804.0" y="128.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">32 mins · 1.1%</text>
+<text x="36.0" y="150.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="500" fill="#3a424b" text-anchor="start">Other</text>
+<rect x="132.0" y="142.0" width="522.0" height="9.0" rx="5" fill="#e7ebef"/>
+<rect x="132.0" y="142.0" width="3.6" height="9.0" rx="5" fill="#3b82f6"/>
+<text x="804.0" y="150.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">21 mins · 0.7%</text>
+<rect x="18.0" y="182.0" width="394.0" height="146.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">EDITORS</text>
+<text x="36.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Claude Code</text>
+<rect x="126.0" y="231.0" width="220.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="126.0" y="231.0" width="216.8" height="8.0" rx="4" fill="url(#g_claude)"/>
+<text x="394.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">98.5%</text>
+<text x="36.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Warp</text>
+<rect x="126.0" y="255.0" width="220.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="126.0" y="255.0" width="1.4" height="8.0" rx="4" fill="#9aa3ad"/>
+<text x="394.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.6%</text>
+<text x="36.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">IntelliJ IDEA</text>
+<rect x="126.0" y="279.0" width="220.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="126.0" y="279.0" width="0.9" height="8.0" rx="4" fill="#9aa3ad"/>
+<text x="394.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.4%</text>
+<text x="36.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">Obsidian</text>
+<rect x="126.0" y="303.0" width="220.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="126.0" y="303.0" width="0.9" height="8.0" rx="4" fill="#9aa3ad"/>
+<text x="394.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">0.4%</text>
+<rect x="428.0" y="182.0" width="394.0" height="146.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="446.0" y="206.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">PROJECTS</text>
+<text x="446.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">bare</text>
+<rect x="532.0" y="231.0" width="224.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="532.0" y="231.0" width="122.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="238.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">54.5%</text>
+<text x="446.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">miner</text>
+<rect x="532.0" y="255.0" width="224.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="532.0" y="255.0" width="89.0" height="8.0" rx="4" fill="url(#g_purple)"/>
+<text x="804.0" y="262.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">39.7%</text>
+<text x="446.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">a20****7</text>
+<rect x="532.0" y="279.0" width="224.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="532.0" y="279.0" width="5.1" height="8.0" rx="4" fill="#9aa3ad"/>
+<text x="804.0" y="286.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">2.3%</text>
+<text x="446.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">dynamic-xche</text>
+<rect x="532.0" y="303.0" width="224.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="532.0" y="303.0" width="3.0" height="8.0" rx="4" fill="#9aa3ad"/>
+<text x="804.0" y="310.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">1.4%</text>
+<rect x="18.0" y="342.0" width="804.0" height="114.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="366.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">DEPENDENCIES</text>
+<text x="804.0" y="366.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">detected libraries</text>
+<text x="36.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">co****l</text>
+<rect x="186.0" y="383.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="186.0" y="383.0" width="44.0" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">24%</text>
+<text x="428.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">io.kotest</text>
+<rect x="578.0" y="383.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="578.0" y="383.0" width="31.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="390.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">17%</text>
+<text x="36.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">org.springframework</text>
+<rect x="186.0" y="407.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="186.0" y="407.0" width="21.2" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">11%</text>
+<text x="428.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">run.ravit</text>
+<rect x="578.0" y="407.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="578.0" y="407.0" width="19.6" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="414.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">11%</text>
+<text x="36.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">kotlinx.coroutines</text>
+<rect x="186.0" y="431.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="186.0" y="431.0" width="15.6" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="412.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">8%</text>
+<text x="428.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#3a424b" text-anchor="start">com.fasterxml</text>
+<rect x="578.0" y="431.0" width="186.0" height="8.0" rx="4" fill="#e7ebef"/>
+<rect x="578.0" y="431.0" width="9.9" height="8.0" rx="4" fill="url(#g_blue)"/>
+<text x="804.0" y="438.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">5%</text>
 </svg>

--- a/cards/week-dark.svg
+++ b/cards/week-dark.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="282" viewBox="0 0 840 282" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="256" viewBox="0 0 840 256" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,56 +6,54 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="270" rx="16" fill="#0d1117" stroke="#20262e"/>
-<rect x="18.0" y="14.0" width="804.0" height="132.0" rx="14" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="38.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#5b6470" text-anchor="start" letter-spacing="1.2" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
-<text x="38.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>
-<text x="120.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#8b949e" text-anchor="start">coding time</text>
-<text x="802.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#7d8590" text-anchor="end">56h vs 46h</text>
-<text x="38.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Coding time</text>
-<text x="279.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#58A6FF"/>
-<rect x="38.0" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="38.0" y="104.0" width="199.8" height="6.0" rx="3" fill="#5b6470"/>
-<text x="38.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 56h</text>
-<text x="279.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 46h</text>
-<text x="299.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">AI lines</text>
-<text x="540.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 59%</text>
-<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#D97757"/>
-<rect x="299.3" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="299.3" y="104.0" width="151.5" height="6.0" rx="3" fill="#5b6470"/>
-<text x="299.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 49.9K</text>
-<text x="540.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 31.3K</text>
-<text x="560.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Tokens</text>
-<text x="802.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#A371F7"/>
-<rect x="560.7" y="104.0" width="241.3" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="560.7" y="104.0" width="199.6" height="6.0" rx="3" fill="#5b6470"/>
-<text x="560.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 3.32B</text>
-<text x="802.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 2.75B</text>
-<text x="18.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">AI Agents</text>
-<line x1="101" y1="164" x2="726" y2="164" stroke="#222a33"/>
-<text x="822.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="end">lines · est. cost</text>
-<rect x="18.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<rect x="36.0" y="206.0" width="18.0" height="18.0" rx="6" fill="#D97757"/>
-<text x="45.0" y="219.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">C</text>
-<text x="62.0" y="220.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#f0f6fc" text-anchor="start">Claude</text>
-<text x="389.0" y="220.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">$7,832</text>
-<text x="36.0" y="246.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">lines</text>
-<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="#1c222b"/>
-<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="url(#g_claude)"/>
-<text x="389.0" y="245.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="end">40,056</text>
-<rect x="433.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#161b22" stroke="#283039" stroke-width="1"/>
-<text x="451.0" y="216.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="600" fill="#5b6470" text-anchor="start" letter-spacing="1" style="text-transform:uppercase">MACHINES</text>
-<text x="451.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">20****7</text>
-<rect x="451.0" y="242.0" width="303.0" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="451.0" y="242.0" width="180.4" height="6.0" rx="3" fill="url(#g_blue)"/>
-<text x="804.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">60%</text>
-<text x="451.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">RAViT</text>
-<rect x="451.0" y="264.0" width="303.0" height="6.0" rx="3" fill="#1c222b"/>
-<rect x="451.0" y="264.0" width="122.6" height="6.0" rx="3" fill="#5b6470"/>
-<text x="804.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">40%</text>
+<rect x="18.0" y="7.0" width="804.0" height="130.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">56h vs 46h</text>
+<text x="36.0" y="57.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>
+<text x="118.0" y="57.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#8b949e" text-anchor="start">coding time</text>
+<text x="36.0" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Coding time</text>
+<text x="278.7" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
+<rect x="36.0" y="89.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="36.0" y="89.0" width="242.7" height="6.0" rx="3" fill="#58A6FF"/>
+<rect x="36.0" y="99.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="36.0" y="99.0" width="200.9" height="6.0" rx="3" fill="#5b6470"/>
+<text x="36.0" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 56h</text>
+<text x="278.7" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 46h</text>
+<text x="298.7" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">AI lines</text>
+<text x="541.3" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 59%</text>
+<rect x="298.7" y="89.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="298.7" y="89.0" width="242.7" height="6.0" rx="3" fill="#D97757"/>
+<rect x="298.7" y="99.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="298.7" y="99.0" width="152.4" height="6.0" rx="3" fill="#5b6470"/>
+<text x="298.7" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 49.9K</text>
+<text x="541.3" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 31.3K</text>
+<text x="561.3" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">Tokens</text>
+<text x="804.0" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
+<rect x="561.3" y="89.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="561.3" y="89.0" width="242.7" height="6.0" rx="3" fill="#A371F7"/>
+<rect x="561.3" y="99.0" width="242.7" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="561.3" y="99.0" width="200.7" height="6.0" rx="3" fill="#5b6470"/>
+<text x="561.3" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="start">now 3.32B</text>
+<text x="804.0" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="end">prev 2.75B</text>
+<rect x="18.0" y="151.0" width="394.0" height="98.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="36.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">AI AGENT</text>
+<text x="394.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#7d8590" text-anchor="end">lines · cost</text>
+<rect x="36.0" y="189.0" width="18.0" height="18.0" rx="6" fill="#D97757"/>
+<text x="45.0" y="202.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">C</text>
+<text x="62.0" y="203.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#f0f6fc" text-anchor="start">Claude</text>
+<text x="394.0" y="203.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#c9d1d9" text-anchor="end">$7,832</text>
+<text x="36.0" y="229.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#5b6470" text-anchor="start">lines</text>
+<rect x="76.0" y="222.0" width="248.0" height="7.0" rx="4" fill="#1c222b"/>
+<rect x="76.0" y="222.0" width="248.0" height="7.0" rx="4" fill="url(#g_claude)"/>
+<text x="394.0" y="228.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#c9d1d9" text-anchor="end">40,056</text>
+<rect x="428.0" y="151.0" width="394.0" height="98.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
+<text x="446.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#58A6FF" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">MACHINES</text>
+<text x="446.0" y="201.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">20****7</text>
+<rect x="530.0" y="194.0" width="230.0" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="530.0" y="194.0" width="136.9" height="6.0" rx="3" fill="url(#g_blue)"/>
+<text x="804.0" y="201.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">60%</text>
+<text x="446.0" y="225.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#c9d1d9" text-anchor="start">RAViT</text>
+<rect x="530.0" y="218.0" width="230.0" height="6.0" rx="3" fill="#1c222b"/>
+<rect x="530.0" y="218.0" width="93.1" height="6.0" rx="3" fill="#5b6470"/>
+<text x="804.0" y="225.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#7d8590" text-anchor="end">40%</text>
 </svg>

--- a/cards/week-light.svg
+++ b/cards/week-light.svg
@@ -1,4 +1,4 @@
-<svg width="840" height="282" viewBox="0 0 840 282" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
+<svg width="840" height="256" viewBox="0 0 840 256" xmlns="http://www.w3.org/2000/svg" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif">
 <defs>
 <linearGradient id="g_claude" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_blue" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#79b8ff"/></linearGradient>
@@ -6,56 +6,54 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<rect x="1" y="6" width="838" height="270" rx="16" fill="#ffffff" stroke="#d0d7de"/>
-<rect x="18.0" y="14.0" width="804.0" height="132.0" rx="14" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="38.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#9aa3ad" text-anchor="start" letter-spacing="1.2" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
-<text x="38.0" y="66.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>
-<text x="120.0" y="66.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#57606a" text-anchor="start">coding time</text>
-<text x="802.0" y="40.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#6e7781" text-anchor="end">56h vs 46h</text>
-<text x="38.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">Coding time</text>
-<text x="279.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="38.0" y="94.0" width="241.3" height="6.0" rx="3" fill="#3b82f6"/>
-<rect x="38.0" y="104.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="38.0" y="104.0" width="199.8" height="6.0" rx="3" fill="#9aa3ad"/>
-<text x="38.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 56h</text>
-<text x="279.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 46h</text>
-<text x="299.3" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">AI lines</text>
-<text x="540.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 59%</text>
-<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="299.3" y="94.0" width="241.3" height="6.0" rx="3" fill="#D97757"/>
-<rect x="299.3" y="104.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="299.3" y="104.0" width="151.5" height="6.0" rx="3" fill="#9aa3ad"/>
-<text x="299.3" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 49.9K</text>
-<text x="540.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 31.3K</text>
-<text x="560.7" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">Tokens</text>
-<text x="802.0" y="86.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
-<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="560.7" y="94.0" width="241.3" height="6.0" rx="3" fill="#A371F7"/>
-<rect x="560.7" y="104.0" width="241.3" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="560.7" y="104.0" width="199.6" height="6.0" rx="3" fill="#9aa3ad"/>
-<text x="560.7" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 3.32B</text>
-<text x="802.0" y="124.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 2.75B</text>
-<text x="18.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.4" style="text-transform:uppercase">AI Agents</text>
-<line x1="101" y1="164" x2="726" y2="164" stroke="#d8dee4"/>
-<text x="822.0" y="168.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="end">lines · est. cost</text>
-<rect x="18.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<rect x="36.0" y="206.0" width="18.0" height="18.0" rx="6" fill="#D97757"/>
-<text x="45.0" y="219.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">C</text>
-<text x="62.0" y="220.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#1f2328" text-anchor="start">Claude</text>
-<text x="389.0" y="220.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#3a424b" text-anchor="end">$7,832</text>
-<text x="36.0" y="246.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">lines</text>
-<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="#e7ebef"/>
-<rect x="74.0" y="239.0" width="253.0" height="7.0" rx="4" fill="url(#g_claude)"/>
-<text x="389.0" y="245.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="end">40,056</text>
-<rect x="433.0" y="190.0" width="389.0" height="78.0" rx="13" fill="#f4f6f8" stroke="#d8dee4" stroke-width="1"/>
-<text x="451.0" y="216.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="600" fill="#9aa3ad" text-anchor="start" letter-spacing="1" style="text-transform:uppercase">MACHINES</text>
-<text x="451.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">20****7</text>
-<rect x="451.0" y="242.0" width="303.0" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="451.0" y="242.0" width="180.4" height="6.0" rx="3" fill="url(#g_blue)"/>
-<text x="804.0" y="236.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">60%</text>
-<text x="451.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">RAViT</text>
-<rect x="451.0" y="264.0" width="303.0" height="6.0" rx="3" fill="#e7ebef"/>
-<rect x="451.0" y="264.0" width="122.6" height="6.0" rx="3" fill="#9aa3ad"/>
-<text x="804.0" y="258.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">40%</text>
+<rect x="18.0" y="7.0" width="804.0" height="130.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">THIS WEEK vs LAST WEEK</text>
+<text x="804.0" y="31.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">56h vs 46h</text>
+<text x="36.0" y="57.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="22" font-weight="700" fill="#2EA043" text-anchor="start" letter-spacing="-0.5">▲ 21%</text>
+<text x="118.0" y="57.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="12" font-weight="500" fill="#57606a" text-anchor="start">coding time</text>
+<text x="36.0" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">Coding time</text>
+<text x="278.7" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
+<rect x="36.0" y="89.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="36.0" y="89.0" width="242.7" height="6.0" rx="3" fill="#3b82f6"/>
+<rect x="36.0" y="99.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="36.0" y="99.0" width="200.9" height="6.0" rx="3" fill="#9aa3ad"/>
+<text x="36.0" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 56h</text>
+<text x="278.7" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 46h</text>
+<text x="298.7" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">AI lines</text>
+<text x="541.3" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 59%</text>
+<rect x="298.7" y="89.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="298.7" y="89.0" width="242.7" height="6.0" rx="3" fill="#D97757"/>
+<rect x="298.7" y="99.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="298.7" y="99.0" width="152.4" height="6.0" rx="3" fill="#9aa3ad"/>
+<text x="298.7" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 49.9K</text>
+<text x="541.3" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 31.3K</text>
+<text x="561.3" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">Tokens</text>
+<text x="804.0" y="81.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#2EA043" text-anchor="end">▲ 21%</text>
+<rect x="561.3" y="89.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="561.3" y="89.0" width="242.7" height="6.0" rx="3" fill="#A371F7"/>
+<rect x="561.3" y="99.0" width="242.7" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="561.3" y="99.0" width="200.7" height="6.0" rx="3" fill="#9aa3ad"/>
+<text x="561.3" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="start">now 3.32B</text>
+<text x="804.0" y="117.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="end">prev 2.75B</text>
+<rect x="18.0" y="151.0" width="394.0" height="98.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="36.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">AI AGENT</text>
+<text x="394.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#6e7781" text-anchor="end">lines · cost</text>
+<rect x="36.0" y="189.0" width="18.0" height="18.0" rx="6" fill="#D97757"/>
+<text x="45.0" y="202.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">C</text>
+<text x="62.0" y="203.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#1f2328" text-anchor="start">Claude</text>
+<text x="394.0" y="203.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="13" font-weight="600" fill="#3a424b" text-anchor="end">$7,832</text>
+<text x="36.0" y="229.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="10" font-weight="500" fill="#9aa3ad" text-anchor="start">lines</text>
+<rect x="76.0" y="222.0" width="248.0" height="7.0" rx="4" fill="#e7ebef"/>
+<rect x="76.0" y="222.0" width="248.0" height="7.0" rx="4" fill="url(#g_claude)"/>
+<text x="394.0" y="228.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3a424b" text-anchor="end">40,056</text>
+<rect x="428.0" y="151.0" width="394.0" height="98.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+<text x="446.0" y="175.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#3b82f6" text-anchor="start" letter-spacing="1.3" style="text-transform:uppercase">MACHINES</text>
+<text x="446.0" y="201.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">20****7</text>
+<rect x="530.0" y="194.0" width="230.0" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="530.0" y="194.0" width="136.9" height="6.0" rx="3" fill="url(#g_blue)"/>
+<text x="804.0" y="201.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">60%</text>
+<text x="446.0" y="225.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#3a424b" text-anchor="start">RAViT</text>
+<rect x="530.0" y="218.0" width="230.0" height="6.0" rx="3" fill="#e7ebef"/>
+<rect x="530.0" y="218.0" width="93.1" height="6.0" rx="3" fill="#9aa3ad"/>
+<text x="804.0" y="225.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="600" fill="#6e7781" text-anchor="end">40%</text>
 </svg>


### PR DESCRIPTION
## Summary
- 밴드 전체 배경 → **컴포넌트(영역)별 단일 플랫 카드** (카드 위 카드 중첩 제거)
- 히어로 AI 링은 **배경 없이 투명**
- AI 에이전트/머신 카드 **동일 높이·행 정렬** (패딩 어긋남 해결)
- 전 카드 **하단 여백 ~18px 통일** (Languages/Editors/Projects 붙음 해소)
- 토큰 통일: radius 14 / 패딩 18 / 간격 14

## Test plan
- [x] 12개 밴드 XML 검증, 마스킹 클린
- [x] dark/light 스택 미리보기 시각 확인