### PR TITLE
style: 히어로 AI 링 Claude 시그니처 오렌지 틴트 배경 복원

### DIFF
--- a/.github/scripts/waka_card.py
+++ b/.github/scripts/waka_card.py
@@ -221,11 +221,15 @@ def band_hero(canvas: Canvas, data: WakaData) -> float:
     theme = canvas.theme
     y = TOP
     hero_h = 132
-    # 히어로(AI 링)는 배경 없음 — 투명
+    # 히어로(AI 링) — Claude 시그니처 오렌지 틴트 카드 (시각적 앵커)
+    hero_bg = "#1b130e" if theme.key == "dark" else "#fdf4ee"
+    hero_stroke = "#4a3527" if theme.key == "dark" else "#efd6c6"
+    canvas.rect(PAD, y, INNER, hero_h, hero_bg, radius=14, stroke=hero_stroke)
+    ring_track = "#2c1e15" if theme.key == "dark" else "#f3ddcf"
     cx, cy, r = PAD + PAD_IN + 52, y + hero_h / 2, 52
     circ = 2 * math.pi * r
     offset = circ * (1 - data.ai_coding_pct / 100.0)
-    canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="{theme.track}" stroke-width="13"/>')
+    canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="{ring_track}" stroke-width="13"/>')
     canvas.add(f'<circle cx="{cx}" cy="{cy:.0f}" r="{r}" fill="none" stroke="url(#g_ring)" stroke-width="13" '
                f'stroke-linecap="round" stroke-dasharray="{circ:.1f}" stroke-dashoffset="{offset:.1f}" '
                f'transform="rotate(-90 {cx} {cy:.0f})"/>')

--- a/cards/hero-dark.svg
+++ b/cards/hero-dark.svg
@@ -6,7 +6,8 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#58A6FF"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<circle cx="88" cy="73" r="52" fill="none" stroke="#1c222b" stroke-width="13"/>
+<rect x="18.0" y="7.0" width="804.0" height="132.0" rx="14" fill="#1b130e" stroke="#4a3527" stroke-width="1"/>
+<circle cx="88" cy="73" r="52" fill="none" stroke="#2c1e15" stroke-width="13"/>
 <circle cx="88" cy="73" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 88 73)"/>
 <text x="88.0" y="71.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#f0f6fc" text-anchor="middle" letter-spacing="-1">100</text>
 <text x="88.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>

--- a/cards/hero-light.svg
+++ b/cards/hero-light.svg
@@ -6,7 +6,8 @@
 <linearGradient id="g_ring" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#D97757"/><stop offset="1" stop-color="#E8A06F"/></linearGradient>
 <linearGradient id="g_peak" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#A371F7"/></linearGradient>
 </defs>
-<circle cx="88" cy="73" r="52" fill="none" stroke="#e7ebef" stroke-width="13"/>
+<rect x="18.0" y="7.0" width="804.0" height="132.0" rx="14" fill="#fdf4ee" stroke="#efd6c6" stroke-width="1"/>
+<circle cx="88" cy="73" r="52" fill="none" stroke="#f3ddcf" stroke-width="13"/>
 <circle cx="88" cy="73" r="52" fill="none" stroke="url(#g_ring)" stroke-width="13" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="0.2" transform="rotate(-90 88 73)"/>
 <text x="88.0" y="71.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" fill="#1f2328" text-anchor="middle" letter-spacing="-1">100</text>
 <text x="88.0" y="89.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="9" font-weight="600" fill="#E8A06F" text-anchor="middle" letter-spacing="1">% AI-DRIVEN</text>


### PR DESCRIPTION
## Summary
- 투명 배경이라 히어로(파이차트)가 페이지에 묻히던 문제 해결
- **Claude 시그니처 오렌지 틴트 카드**로 시각적 앵커 부여 (dark 웜다크 / light 크림)
- 나머지 중립 카드와 대비되어 존재감 확보

## Test plan
- [x] dark/light 미리보기 확인, XML·마스킹 통과