### PR TITLE
style: stat 타일 단위 처리 정리 + 의미별 톤다운 색

### DIFF
--- a/.github/scripts/waka_card.py
+++ b/.github/scripts/waka_card.py
@@ -91,6 +91,18 @@ def fmt_count(number: float) -> str:
     return f"{int(number)}"
 
 
+def split_count(number: float) -> tuple[str, str]:
+    """숫자를 (mantissa, 단위) 로 분리. 단위는 일관된 작은 스타일로 별도 렌더."""
+    number = float(number)
+    if number >= 1e9:
+        return f"{number / 1e9:.2f}", "B"
+    if number >= 1e6:
+        return f"{number / 1e6:.1f}", "M"
+    if number >= 1e3:
+        return f"{number / 1e3:.1f}", "K"
+    return f"{int(number)}", ""
+
+
 def fmt_money(number: float) -> str:
     return "$" + f"{number:,.0f}"
 
@@ -110,13 +122,14 @@ class Canvas:
         self.parts.append(markup)
 
     def text(self, x, y, value, size=12, color=None, weight=400, family=MONO,
-             anchor="start", spacing=None, upper=False):
+             anchor="start", spacing=None, upper=False, opacity=None):
         color = color or self.theme.foreground
         letter = f' letter-spacing="{spacing}"' if spacing else ""
         transform = ' style="text-transform:uppercase"' if upper else ""
+        op = f' fill-opacity="{opacity}"' if opacity is not None else ""
         self.add(
             f'<text x="{x:.1f}" y="{y:.1f}" font-family="{family}" font-size="{size}" '
-            f'font-weight="{weight}" fill="{color}" text-anchor="{anchor}"{letter}{transform}>'
+            f'font-weight="{weight}" fill="{color}"{op} text-anchor="{anchor}"{letter}{transform}>'
             f'{esc(value)}</text>'
         )
 
@@ -258,20 +271,32 @@ def band_hero(canvas: Canvas, data: WakaData) -> float:
     canvas.bar(bx, row + 8, bw, 9, human_pct, GREEN, radius=5)
 
     y += hero_h + GAP
+    out_m, out_u = split_count(data.tokens_out)
+    in_m, in_u = split_count(data.tokens_in)
+    line_m, line_u = split_count(data.ai_lines)
+    # 각 타일: (강조색, 접두 단위, 숫자, 후위 단위, 캡션) — 단위는 의미별 색 코드
     tiles = [
-        (fmt_count(data.ai_lines), "AI line changes", None),
-        (fmt_count(data.tokens_in), f"tokens in · {fmt_count(data.tokens_out)} out", "B"),
-        (fmt_money(data.est_cost), "est. cost · 7 days", None),
-        (f"{data.lines_per_prompt:.0f}", "lines / prompt", None),
+        (CLAUDE, "", line_m, line_u, "AI line changes"),
+        (theme.blue, "", in_m, in_u, f"tokens in · {out_m}{out_u} out"),
+        (PURPLE, "$", f"{data.est_cost:,.0f}", "", "est. cost · 7 days"),
+        (GREEN, "", f"{data.lines_per_prompt:.0f}", "", "lines / prompt"),
     ]
     tile_gap = 12
     tile_w = (INNER - tile_gap * 3) / 4
-    for index, (value, label, suffix) in enumerate(tiles):
+
+    def num_width(text):
+        return sum(7.0 if ch == "." else 6.0 if ch == "," else 15.5 for ch in text)
+
+    for index, (accent, prefix, mantissa, unit, label) in enumerate(tiles):
         tx = PAD + index * (tile_w + tile_gap)
         canvas.card(tx, y, tile_w, 72)
-        canvas.text(tx + PAD_IN, y + 32, value, 25, theme.foreground, 700, SANS, spacing="-0.5")
-        if suffix:
-            canvas.text(tx + PAD_IN + len(value) * 15.5, y + 32, suffix, 16, theme.blue, 700, SANS)
+        vx = tx + PAD_IN
+        if prefix:
+            canvas.text(vx, y + 31, prefix, 15, accent, 700, SANS, opacity=0.72)
+            vx += 12
+        canvas.text(vx, y + 32, mantissa, 25, theme.foreground, 700, SANS, spacing="-0.5")
+        if unit:
+            canvas.text(vx + num_width(mantissa) + 3, y + 31, unit, 14, accent, 700, SANS, opacity=0.72)
         canvas.text(tx + PAD_IN, y + 54, label, 11, theme.mute, 500, MONO)
     return y + 72
 

--- a/cards/hero-dark.svg
+++ b/cards/hero-dark.svg
@@ -25,14 +25,16 @@
 <rect x="186.0" y="105.0" width="618.0" height="9.0" rx="5" fill="#1c222b"/>
 <rect x="186.0" y="105.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
 <rect x="18.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
-<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">50.8K</text>
+<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">50.8</text>
+<text x="92.5" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#D97757" fill-opacity="0.72" text-anchor="start">K</text>
 <text x="36.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">AI line changes</text>
 <rect x="222.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
-<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">3.71B</text>
-<text x="317.5" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#58A6FF" text-anchor="start">B</text>
+<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">3.71</text>
+<text x="296.5" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#58A6FF" fill-opacity="0.72" text-anchor="start">B</text>
 <text x="240.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">tokens in · 5.6M out</text>
 <rect x="426.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
-<text x="444.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">$10,774</text>
+<text x="444.0" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#A371F7" fill-opacity="0.72" text-anchor="start">$</text>
+<text x="456.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">10,774</text>
 <text x="444.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#7d8590" text-anchor="start">est. cost · 7 days</text>
 <rect x="630.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#0d1117" stroke="#20262e" stroke-width="1"/>
 <text x="648.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#f0f6fc" text-anchor="start" letter-spacing="-0.5">89</text>

--- a/cards/hero-light.svg
+++ b/cards/hero-light.svg
@@ -25,14 +25,16 @@
 <rect x="186.0" y="105.0" width="618.0" height="9.0" rx="5" fill="#e7ebef"/>
 <rect x="186.0" y="105.0" width="0.0" height="9.0" rx="5" fill="#2EA043"/>
 <rect x="18.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
-<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">50.8K</text>
+<text x="36.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">50.8</text>
+<text x="92.5" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#D97757" fill-opacity="0.72" text-anchor="start">K</text>
 <text x="36.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">AI line changes</text>
 <rect x="222.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
-<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">3.71B</text>
-<text x="317.5" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="#3b82f6" text-anchor="start">B</text>
+<text x="240.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">3.71</text>
+<text x="296.5" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="14" font-weight="700" fill="#3b82f6" fill-opacity="0.72" text-anchor="start">B</text>
 <text x="240.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">tokens in · 5.6M out</text>
 <rect x="426.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
-<text x="444.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">$10,774</text>
+<text x="444.0" y="184.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="15" font-weight="700" fill="#A371F7" fill-opacity="0.72" text-anchor="start">$</text>
+<text x="456.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">10,774</text>
 <text x="444.0" y="207.0" font-family="'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="11" font-weight="500" fill="#6e7781" text-anchor="start">est. cost · 7 days</text>
 <rect x="630.0" y="153.0" width="192.0" height="72.0" rx="14" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
 <text x="648.0" y="185.0" font-family="'Space Grotesk','Segoe UI',system-ui,-apple-system,sans-serif" font-size="25" font-weight="700" fill="#1f2328" text-anchor="start" letter-spacing="-0.5">89</text>


### PR DESCRIPTION
## Summary
- 숫자/단위 분리(`split_count`) — 단위(K/M/B/$)를 일관된 작은 스타일로 별도 렌더
- **토큰 타일 이중 'B' 렌더 버그 수정**
- 단위에 의미별 강조색 + opacity 0.72 톤다운 (라인=Claude · 토큰=블루 · 비용=퍼플)

## Test plan
- [x] dark/light 타일 미리보기 확인, 이중 B 제거 검증, XML·마스킹 통과